### PR TITLE
クエスト追加機能を実装

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:g_sui_hunter/models/tag_model.dart';
 import 'package:g_sui_hunter/models/user_auth_model.dart';
 import 'package:g_sui_hunter/models/hunter_model.dart';
 import 'package:g_sui_hunter/models/quest_model.dart';
@@ -26,6 +27,9 @@ class MyApp extends StatelessWidget {
         ),
         ChangeNotifierProvider<QuestModel>(
           create: (context) => QuestModel()..fetchQuest(),
+        ),
+        ChangeNotifierProvider<TagModel>(
+          create: (context) => TagModel()..fetchTag(),
         ),
       ],
       child: MaterialApp(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:g_sui_hunter/models/user_auth_model.dart';
+import 'package:g_sui_hunter/views/add_quest_page.dart';
 import 'package:g_sui_hunter/views/root_page.dart';
 import 'package:provider/provider.dart';
 
@@ -25,6 +26,7 @@ class MyApp extends StatelessWidget {
         initialRoute: '/',
         routes: {
           '/': (BuildContext context) => RootPage(),
+          '/add_quest': (BuildContext context) => AddQuestPage(),
         },
       ),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,7 +12,6 @@ void main() async {
 }
 
 class MyApp extends StatelessWidget {
-
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:g_sui_hunter/models/user_auth_model.dart';
+import 'package:g_sui_hunter/models/hunter_model.dart';
+import 'package:g_sui_hunter/models/quest_model.dart';
 import 'package:g_sui_hunter/views/add_quest_page.dart';
 import 'package:g_sui_hunter/views/root_page.dart';
 import 'package:provider/provider.dart';
@@ -14,8 +16,18 @@ void main() async {
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider(
-      create: (context) => UserAuthModel()..getUserState(),
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(
+          create: (context) => UserAuthModel()..getUserState(),
+        ),
+        ChangeNotifierProvider<HunterModel>(
+          create: (context) => HunterModel()..fetchHunter(),
+        ),
+        ChangeNotifierProvider<QuestModel>(
+          create: (context) => QuestModel()..fetchQuest(),
+        ),
+      ],
       child: MaterialApp(
         title: '自炊ハンター',
         theme: ThemeData(

--- a/lib/models/add_quest_model.dart
+++ b/lib/models/add_quest_model.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 
 class AddQuestModel extends ChangeNotifier{
   String questName;
+  String groupValue = '0';
+  final List<String> questRank = ['1', '2', '3', '4', '5',];
 
   void changeQuestName(String questName) {
     this.questName = questName;

--- a/lib/models/add_quest_model.dart
+++ b/lib/models/add_quest_model.dart
@@ -1,10 +1,12 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
+import 'package:g_sui_hunter/models/tag.dart';
 
 class AddQuestModel extends ChangeNotifier{
   String questName;
   String groupValue = '0';
   final List<String> questRank = ['1', '2', '3', '4', '5',];
+  Map<String, bool> checkBoxState = {};
 
   void changeQuestName(String questName) {
     this.questName = questName;
@@ -13,6 +15,13 @@ class AddQuestModel extends ChangeNotifier{
   void choiceRank(String value) {
     this.groupValue = value;
     notifyListeners();
+  }
+
+  void createCheckBoxState(List<Tag> tagList) {
+    tagList.forEach((tag) {
+      checkBoxState[tag.name] = false;
+      print(tag.name);
+    });
   }
 
   Future add() async{

--- a/lib/models/add_quest_model.dart
+++ b/lib/models/add_quest_model.dart
@@ -2,7 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:g_sui_hunter/models/tag.dart';
 
-class AddQuestModel extends ChangeNotifier{
+class AddQuestModel extends ChangeNotifier {
   String questName;
   String groupValue = '0';
   final List<String> questRank = ['1', '2', '3', '4', '5',];
@@ -20,8 +20,13 @@ class AddQuestModel extends ChangeNotifier{
   void createCheckBoxState(List<Tag> tagList) {
     tagList.forEach((tag) {
       checkBoxState[tag.name] = false;
-      print(tag.name);
     });
+    notifyListeners();
+  }
+
+  void choiceTag(String tagName, bool checkState) {
+    this.checkBoxState[tagName] = checkState;
+    notifyListeners();
   }
 
   Future add() async{

--- a/lib/models/add_quest_model.dart
+++ b/lib/models/add_quest_model.dart
@@ -10,6 +10,11 @@ class AddQuestModel extends ChangeNotifier{
     this.questName = questName;
   }
 
+  void choiceRank(String value) {
+    this.groupValue = value;
+    notifyListeners();
+  }
+
   Future add() async{
     final collection = FirebaseFirestore.instance.collection("questList");
     await collection.add({

--- a/lib/models/add_quest_model.dart
+++ b/lib/models/add_quest_model.dart
@@ -1,0 +1,17 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+class AddQuestModel extends ChangeNotifier{
+  String questName;
+
+  void changeQuestName(String questName) {
+    this.questName = questName;
+  }
+
+  Future add() async{
+    final collection = FirebaseFirestore.instance.collection("questList");
+    await collection.add({
+      'quest_name': this.questName,
+    });
+  }
+}

--- a/lib/models/add_quest_model.dart
+++ b/lib/models/add_quest_model.dart
@@ -7,6 +7,7 @@ class AddQuestModel extends ChangeNotifier {
   String groupValue = '0';
   final List<String> questRank = ['1', '2', '3', '4', '5',];
   Map<String, bool> checkBoxState = {};
+  Set<String> _tags = {};
 
   void changeQuestName(String questName) {
     this.questName = questName;
@@ -25,14 +26,22 @@ class AddQuestModel extends ChangeNotifier {
   }
 
   void choiceTag(String tagName, bool checkState) {
+    if (checkState == true) {
+      _tags.add(tagName);
+    }
     this.checkBoxState[tagName] = checkState;
     notifyListeners();
   }
 
-  Future add() async{
-    final collection = FirebaseFirestore.instance.collection("questList");
+  Future add() async {
+    final collection = FirebaseFirestore.instance.collection("quests");
     await collection.add({
-      'quest_name': this.questName,
+      'title': this.questName,
+      'siteUrl': '',
+      'imageUrl': '',
+      'rank': int.parse(this.groupValue),
+      'timeAve': 0,
+      'tags': _tags.toList(),
     });
   }
 }

--- a/lib/models/hunter_model.dart
+++ b/lib/models/hunter_model.dart
@@ -4,9 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:g_sui_hunter/models/hunter.dart';
 
 class HunterModel extends ChangeNotifier {
-  HunterModel(this.currentUser);
-
-  User currentUser;
+  User currentUser = FirebaseAuth.instance.currentUser;
   Hunter hunter;
 
   Future fetchHunter() async {

--- a/lib/models/quest_model.dart
+++ b/lib/models/quest_model.dart
@@ -4,6 +4,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 
 class QuestModel extends ChangeNotifier {
   List<Quest> questList = [];
+  String questName;
 
   void fetchQuest() async {
     final QuerySnapshot questSnapshots = await FirebaseFirestore.instance.collection('quests').get();
@@ -12,10 +13,11 @@ class QuestModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future add(String questName) async{
+
+  Future add() async{
     final collection = FirebaseFirestore.instance.collection("questList");
     await collection.add({
-      'name': questName,
+      'name': this.questName,
     });
   }
 }

--- a/lib/models/quest_model.dart
+++ b/lib/models/quest_model.dart
@@ -4,20 +4,11 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 
 class QuestModel extends ChangeNotifier {
   List<Quest> questList = [];
-  String questName;
 
   void fetchQuest() async {
     final QuerySnapshot questSnapshots = await FirebaseFirestore.instance.collection('quests').get();
     final questList = questSnapshots.docs.map((doc) => Quest(doc)).toList();
     this.questList = questList;
     notifyListeners();
-  }
-
-
-  Future add() async{
-    final collection = FirebaseFirestore.instance.collection("questList");
-    await collection.add({
-      'name': this.questName,
-    });
   }
 }

--- a/lib/models/quest_model.dart
+++ b/lib/models/quest_model.dart
@@ -11,4 +11,11 @@ class QuestModel extends ChangeNotifier {
     this.questList = questList;
     notifyListeners();
   }
+
+  Future add(String questName) async{
+    final collection = FirebaseFirestore.instance.collection("questList");
+    await collection.add({
+      'name': questName,
+    });
+  }
 }

--- a/lib/models/tag.dart
+++ b/lib/models/tag.dart
@@ -1,0 +1,11 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class Tag {
+  Tag(DocumentSnapshot doc) {
+    this.name = doc.data()['name'];
+    this.quests = doc.data()['quests'] ?? null;
+  }
+
+  String name;
+  List<dynamic> quests;
+}

--- a/lib/models/tag_model.dart
+++ b/lib/models/tag_model.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:g_sui_hunter/models/tag.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class TagModel extends ChangeNotifier {
+  List<Tag> tagList = [];
+
+  void fetchTag() async {
+    final QuerySnapshot tagSnapshots = await FirebaseFirestore.instance.collection('tags').get();
+    final tagList = tagSnapshots.docs.map((doc) => Tag(doc)).toList();
+    this.tagList = tagList;
+    notifyListeners();
+  }
+}

--- a/lib/views/add_quest_form.dart
+++ b/lib/views/add_quest_form.dart
@@ -1,58 +1,75 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:g_sui_hunter/models/add_quest_model.dart';
+import 'package:g_sui_hunter/models/tag.dart';
+import 'package:g_sui_hunter/models/tag_model.dart';
 import 'package:provider/provider.dart';
 
-class AddQuestForm extends StatefulWidget {
-  @override
-  _AddQuestFormState createState() => _AddQuestFormState();
-}
+class AddQuestForm extends StatelessWidget {
 
-class _AddQuestFormState extends State<AddQuestForm> {
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        TextField(
-          decoration: InputDecoration(
-            labelText: "クエスト名を入力してください",
-            hintText: "例：激辛カレー",
-          ),
-          onChanged: (text) {
-            context.read<AddQuestModel>().changeQuestName(text);
-          },
-        ),
-        Selector<AddQuestModel, String>(
-          selector: (context, model) => model.groupValue,
-          builder: (context, groupValue, child) {
-            final questRank = context.select<AddQuestModel, List<String>>(
-                  (value) => value.questRank,
-            );
-            final rankChoices = questRank.map((value) => Column(
-              children: [
-                Radio(
-                  value: value,
-                  groupValue: groupValue,
-                  onChanged: (value) => context.read<AddQuestModel>().choiceRank(value),
-                ),
-                Text(value),
-              ],
+    return SingleChildScrollView(
+      child: Column(
+        children: [
+          TextField(
+            decoration: InputDecoration(
+              labelText: "クエスト名を入力してください",
+              hintText: "例：激辛カレー",
             ),
-            ).toList();
-            return Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: rankChoices,
-            );
-          },
-        ),
-        RaisedButton(
-          child: Text("クエスト追加"),
-          onPressed: () async{
-            await context.read<AddQuestModel>().add();
-            Navigator.pop(context);
-          },
-        ),
-      ],
+            onChanged: (text) {
+              context.read<AddQuestModel>().changeQuestName(text);
+            },
+          ),
+          Selector<AddQuestModel, String>(
+            selector: (context, model) => model.groupValue,
+            builder: (context, groupValue, child) {
+              final questRank = context.select<AddQuestModel, List<String>>(
+                    (value) => value.questRank,
+              );
+              final rankChoices = questRank.map((value) => Column(
+                children: [
+                  Radio(
+                    value: value,
+                    groupValue: groupValue,
+                    onChanged: (value) => context.read<AddQuestModel>().choiceRank(value),
+                  ),
+                  Text(value),
+                ],
+              ),
+              ).toList();
+              return Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: rankChoices,
+              );
+            },
+          ),
+          Selector<TagModel, List<Tag>>(
+            selector: (context, model) => model.tagList,
+            builder: (context, tagList, child) {
+              final checkBox = tagList.map((tag) {
+                return CheckboxListTile(
+                  title: Text(tag.name),
+                  value: true,
+                  onChanged: (value) {
+                    print(tag);
+                  },
+                );
+              }).toList();
+
+              return Column(
+                children: checkBox,
+              );
+            },
+          ),
+          RaisedButton(
+            child: Text("クエスト追加"),
+            onPressed: () async{
+              await context.read<AddQuestModel>().add();
+              Navigator.pop(context);
+            },
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/views/add_quest_form.dart
+++ b/lib/views/add_quest_form.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:g_sui_hunter/models/add_quest_model.dart';
-import 'package:g_sui_hunter/models/tag.dart';
-import 'package:g_sui_hunter/models/tag_model.dart';
 import 'package:provider/provider.dart';
 
 class AddQuestForm extends StatelessWidget {
@@ -43,15 +41,14 @@ class AddQuestForm extends StatelessWidget {
               );
             },
           ),
-          Selector<TagModel, List<Tag>>(
-            selector: (context, model) => model.tagList,
-            builder: (context, tagList, child) {
-              final checkBox = tagList.map((tag) {
+          Consumer<AddQuestModel>(
+            builder: (context, model, child) {
+              final checkBox = model.checkBoxState.entries.map((checkBox) {
                 return CheckboxListTile(
-                  title: Text(tag.name),
-                  value: true,
+                  title: Text(checkBox.key),
+                  value: checkBox.value,
                   onChanged: (value) {
-                    print(tag);
+                    context.read<AddQuestModel>().choiceTag(checkBox.key, value);
                   },
                 );
               }).toList();

--- a/lib/views/add_quest_form.dart
+++ b/lib/views/add_quest_form.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:g_sui_hunter/models/add_quest_model.dart';
+import 'package:provider/provider.dart';
+
+class AddQuestForm extends StatefulWidget {
+  @override
+  _AddQuestFormState createState() => _AddQuestFormState();
+}
+
+class _AddQuestFormState extends State<AddQuestForm> {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        TextField(
+          decoration: InputDecoration(
+            labelText: "クエスト名を入力してください",
+            hintText: "例：激辛カレー",
+          ),
+          onChanged: (text) {
+            context.read<AddQuestModel>().changeQuestName(text);
+          },
+        ),
+        RaisedButton(
+          child: Text("クエスト追加"),
+          onPressed: () async{
+            await context.read<AddQuestModel>().add();
+            Navigator.pop(context);
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/lib/views/add_quest_form.dart
+++ b/lib/views/add_quest_form.dart
@@ -22,6 +22,29 @@ class _AddQuestFormState extends State<AddQuestForm> {
             context.read<AddQuestModel>().changeQuestName(text);
           },
         ),
+        Selector<AddQuestModel, String>(
+          selector: (context, model) => model.groupValue,
+          builder: (context, model, child) {
+            final questRank = context.select<AddQuestModel, List<String>>(
+                  (value) => value.questRank,
+            );
+            final rankChoices = questRank.map((value) => Column(
+              children: [
+                Radio(
+                  value: value,
+                  groupValue: null,
+                  onChanged: null,
+                ),
+                Text(value),
+              ],
+            ),
+            ).toList();
+            return Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: rankChoices,
+            );
+          },
+        ),
         RaisedButton(
           child: Text("クエスト追加"),
           onPressed: () async{

--- a/lib/views/add_quest_form.dart
+++ b/lib/views/add_quest_form.dart
@@ -24,7 +24,7 @@ class _AddQuestFormState extends State<AddQuestForm> {
         ),
         Selector<AddQuestModel, String>(
           selector: (context, model) => model.groupValue,
-          builder: (context, model, child) {
+          builder: (context, groupValue, child) {
             final questRank = context.select<AddQuestModel, List<String>>(
                   (value) => value.questRank,
             );
@@ -32,8 +32,8 @@ class _AddQuestFormState extends State<AddQuestForm> {
               children: [
                 Radio(
                   value: value,
-                  groupValue: null,
-                  onChanged: null,
+                  groupValue: groupValue,
+                  onChanged: (value) => context.read<AddQuestModel>().choiceRank(value),
                 ),
                 Text(value),
               ],

--- a/lib/views/add_quest_page.dart
+++ b/lib/views/add_quest_page.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:g_sui_hunter/models/quest_model.dart';
 
 class AddQuestPage extends StatelessWidget {
   @override
@@ -17,6 +19,7 @@ class AddQuestPage extends StatelessWidget {
           RaisedButton(
             child: Text("クエスト追加"),
             onPressed: (){
+              context.read<QuestModel>().add('カレーうどん');
               Navigator.pop(context);
             },
           ),

--- a/lib/views/add_quest_page.dart
+++ b/lib/views/add_quest_page.dart
@@ -1,40 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:g_sui_hunter/models/add_quest_model.dart';
+import 'package:g_sui_hunter/views/add_quest_form.dart';
 import 'package:provider/provider.dart';
-import 'package:g_sui_hunter/models/quest_model.dart';
 
 class AddQuestPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<AddQuestModel>(
       create: (_) => AddQuestModel(),
-      builder: (context, child) {
-        return Scaffold(
-          appBar: AppBar(
-            title: Text('新規追加'),
-          ),
-          body: Column(
-            children: [
-              TextField(
-                decoration: InputDecoration(
-                  labelText: "クエスト名を入力してください",
-                  hintText: "例：激辛カレー",
-                ),
-                onChanged: (text) {
-                  context.read<AddQuestModel>().changeQuestName(text);
-                },
-              ),
-              RaisedButton(
-                child: Text("クエスト追加"),
-                onPressed: () async{
-                  await context.read<AddQuestModel>().add();
-                  Navigator.pop(context);
-                },
-              ),
-            ],
-          ),
-        );
-      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text('新規追加'),
+        ),
+        body: AddQuestForm(),
+      ),
     );
   }
 }

--- a/lib/views/add_quest_page.dart
+++ b/lib/views/add_quest_page.dart
@@ -1,36 +1,40 @@
 import 'package:flutter/material.dart';
+import 'package:g_sui_hunter/models/add_quest_model.dart';
 import 'package:provider/provider.dart';
 import 'package:g_sui_hunter/models/quest_model.dart';
 
 class AddQuestPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text('新規追加'),
-      ),
-      body: Consumer<QuestModel>(builder: (context, model, child) {
-        return Column(
-          children: [
-            TextField(
-              decoration: InputDecoration(
-                labelText: "クエスト名を入力してください",
-                hintText: "例：激辛カレー",
+    return ChangeNotifierProvider<AddQuestModel>(
+      create: (_) => AddQuestModel(),
+      builder: (context, child) {
+        return Scaffold(
+          appBar: AppBar(
+            title: Text('新規追加'),
+          ),
+          body: Column(
+            children: [
+              TextField(
+                decoration: InputDecoration(
+                  labelText: "クエスト名を入力してください",
+                  hintText: "例：激辛カレー",
+                ),
+                onChanged: (text) {
+                  context.read<AddQuestModel>().changeQuestName(text);
+                },
               ),
-              onChanged: (text) {
-                model.questName = text;
-              },
-            ),
-            RaisedButton(
-              child: Text("クエスト追加"),
-              onPressed: () async{
-                await model.add();
-                Navigator.pop(context);
-              },
-            ),
-          ],
+              RaisedButton(
+                child: Text("クエスト追加"),
+                onPressed: () async{
+                  await context.read<AddQuestModel>().add();
+                  Navigator.pop(context);
+                },
+              ),
+            ],
+          ),
         );
-      }),
+      },
     );
   }
 }

--- a/lib/views/add_quest_page.dart
+++ b/lib/views/add_quest_page.dart
@@ -9,22 +9,28 @@ class AddQuestPage extends StatelessWidget {
       appBar: AppBar(
         title: Text('新規追加'),
       ),
-      body: Column(
-        children: [
-          TextField(
-            decoration: InputDecoration(
+      body: Consumer<QuestModel>(builder: (context, model, child) {
+        return Column(
+          children: [
+            TextField(
+              decoration: InputDecoration(
                 labelText: "クエスト名を入力してください",
-                hintText: "例：激辛カレー"),
-          ),
-          RaisedButton(
-            child: Text("クエスト追加"),
-            onPressed: (){
-              context.read<QuestModel>().add('カレーうどん');
-              Navigator.pop(context);
-            },
-          ),
-        ],
-      ),
+                hintText: "例：激辛カレー",
+              ),
+              onChanged: (text) {
+                model.questName = text;
+              },
+            ),
+            RaisedButton(
+              child: Text("クエスト追加"),
+              onPressed: () async{
+                await model.add();
+                Navigator.pop(context);
+              },
+            ),
+          ],
+        );
+      }),
     );
   }
 }

--- a/lib/views/add_quest_page.dart
+++ b/lib/views/add_quest_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:g_sui_hunter/models/add_quest_model.dart';
+import 'package:g_sui_hunter/models/tag_model.dart';
 import 'package:g_sui_hunter/views/add_quest_form.dart';
 import 'package:provider/provider.dart';
 
@@ -7,7 +8,10 @@ class AddQuestPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<AddQuestModel>(
-      create: (_) => AddQuestModel(),
+      create: (_) {
+        final tagList = context.read<TagModel>().tagList;
+        return AddQuestModel()..createCheckBoxState(tagList);
+      },
       child: Scaffold(
         appBar: AppBar(
           title: Text('新規追加'),

--- a/lib/views/add_quest_page.dart
+++ b/lib/views/add_quest_page.dart
@@ -3,8 +3,25 @@ import 'package:flutter/material.dart';
 class AddQuestPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Container(
-      color: Colors.red,
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('新規追加'),
+      ),
+      body: Column(
+        children: [
+          TextField(
+            decoration: InputDecoration(
+                labelText: "クエスト名を入力してください",
+                hintText: "例：激辛カレー"),
+          ),
+          RaisedButton(
+            child: Text("クエスト追加"),
+            onPressed: (){
+              Navigator.pop(context);
+            },
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/views/add_quest_page.dart
+++ b/lib/views/add_quest_page.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class AddQuestPage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.red,
+    );
+  }
+}

--- a/lib/views/home_page.dart
+++ b/lib/views/home_page.dart
@@ -1,9 +1,8 @@
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:g_sui_hunter/models/hunter.dart';
 import 'package:g_sui_hunter/models/hunter_model.dart';
-import 'package:g_sui_hunter/models/quest_model.dart';
-import 'package:g_sui_hunter/models/user_auth_model.dart';
+import 'package:g_sui_hunter/models/tag.dart';
+import 'package:g_sui_hunter/models/tag_model.dart';
 import 'package:g_sui_hunter/views/quest_list_page.dart';
 import 'package:provider/provider.dart';
 
@@ -11,7 +10,8 @@ class HomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final hunter = context.select<HunterModel, Hunter>((value) => value.hunter);
-    if (hunter == null) {
+    final tagList = context.select<TagModel, List<Tag>>((value) => value.tagList);
+    if (hunter == null || tagList == []) {
       return Scaffold(
         appBar: AppBar(),
         body: Center(

--- a/lib/views/home_page.dart
+++ b/lib/views/home_page.dart
@@ -10,29 +10,16 @@ import 'package:provider/provider.dart';
 class HomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final user = context.select<UserAuthModel, User>((value) => value.user);
-    return MultiProvider(
-      providers: [
-        ChangeNotifierProvider<HunterModel>(
-          create: (context) => HunterModel(user)..fetchHunter(),
+    final hunter = context.select<HunterModel, Hunter>((value) => value.hunter);
+    if (hunter == null) {
+      return Scaffold(
+        appBar: AppBar(),
+        body: Center(
+          child: CircularProgressIndicator(),
         ),
-        ChangeNotifierProvider<QuestModel>(
-          create: (context) => QuestModel()..fetchQuest(),
-        ),
-      ],
-      builder: (context, child) {
-        final hunter = context.select<HunterModel, Hunter>((value) => value.hunter);
-        if (hunter == null) {
-          return Scaffold(
-            appBar: AppBar(),
-            body: Center(
-              child: CircularProgressIndicator(),
-            ),
-          );
-        } else {
-          return QuestListPage();
-        }
-      },
-    );
+      );
+    } else {
+      return QuestListPage();
+    }
   }
 }

--- a/lib/views/quest_list_page.dart
+++ b/lib/views/quest_list_page.dart
@@ -78,7 +78,12 @@ class QuestListPage extends StatelessWidget {
                 child: SizedBox(
                   width: 40,
                   height: 40,
-                  child: Icon(Icons.control_point_rounded),
+                  child: IconButton(
+                    icon: Icon(Icons.control_point_rounded),
+                    onPressed: () {
+                      Navigator.pushNamed(context,'/add_quest');
+                    },
+                  ),
                 ),
               ),
             ],


### PR DESCRIPTION
### 追加
- 新規クエスト追加画面(`add_quest_page`)
  - タイトル入力用テキストフィールド
  - クエストランク選択用ラジオボタン
  - タグ選択用チェックボックス
  - firestoreに追加ボタン
- tagクラス、モデル
### 変更・修正
- ページ遷移してもModelを扱えるようにするため、MultiProviderをMaterialAppの上に移動
- MultiProviderの移動で不要になったので、HunterモデルのcurrentUserはFirebaseAuthインスタンスから取得

### 画面
<img src='https://user-images.githubusercontent.com/39556764/101275724-52bea480-37eb-11eb-8a9c-c58e7f76e73f.png' height='500'>
