### PR TITLE
チェックボックスの選択解除しても値が保存されてしまうのを修正

### DIFF
--- a/lib/models/add_quest_model.dart
+++ b/lib/models/add_quest_model.dart
@@ -28,6 +28,8 @@ class AddQuestModel extends ChangeNotifier {
   void choiceTag(String tagName, bool checkState) {
     if (checkState == true) {
       _tags.add(tagName);
+    }else{
+      _tags.remove(tagName);
     }
     this.checkBoxState[tagName] = checkState;
     notifyListeners();

--- a/lib/models/add_quest_model.dart
+++ b/lib/models/add_quest_model.dart
@@ -28,7 +28,7 @@ class AddQuestModel extends ChangeNotifier {
   void choiceTag(String tagName, bool checkState) {
     if (checkState == true) {
       _tags.add(tagName);
-    }else{
+    } else {
       _tags.remove(tagName);
     }
     this.checkBoxState[tagName] = checkState;


### PR DESCRIPTION
if文の中に、チェックボックスが選択されたときにタグがfirebaseに保存される処理しか書かれてなかったので、そこにelseを入れて、チェックボックスの選択が解除されたときに、タグの保存を取り除く処理を書きました。