### PR TITLE
クエスト受注機能を追加

### DIFF
--- a/lib/models/hunter.dart
+++ b/lib/models/hunter.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 
 class Hunter{
   Hunter(DocumentSnapshot doc){
+    this.id = doc.id;
     this.name = doc.data()['name'];
     this.rank = doc.data()['rank'];
     this.exp = doc.data()['exp'];
@@ -9,10 +10,11 @@ class Hunter{
     this.quests = doc.data()['quests'];
     this.skills = doc.data()['skills'];
   }
+  String id;
   String name;
   int rank;
   int exp;
   DocumentReference currentQuest;
-  List<DocumentReference> quests;
+  List<dynamic> quests;
   Map<String, int> skills;
 }

--- a/lib/models/hunter_model.dart
+++ b/lib/models/hunter_model.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:g_sui_hunter/models/hunter.dart';
+import 'package:g_sui_hunter/models/quest.dart';
 
 class HunterModel extends ChangeNotifier {
   User currentUser = FirebaseAuth.instance.currentUser;
@@ -28,5 +29,24 @@ class HunterModel extends ChangeNotifier {
           .catchError((error) => print("Failed to add hunter: $error"));
     }
     notifyListeners();
+  }
+
+  Future orderQuest(Quest data) async {
+    final hunterRef = FirebaseFirestore.instance.collection('hunters').doc(hunter.id);
+    final questRef = FirebaseFirestore.instance.collection('quests').doc(data.id);
+
+    hunter.currentQuest  = questRef;
+    if (hunter.quests == null) {
+      hunter.quests = [questRef];
+    } else {
+      hunter.quests.add(questRef);
+    }
+
+    hunterRef.update({
+      'currentQuest': questRef,
+      'quests': FieldValue.arrayUnion(hunter.quests),
+    })
+        .then((value) => notifyListeners())
+        .catchError((error) => print("Failed to order quest: $error"));
   }
 }

--- a/lib/models/hunter_model.dart
+++ b/lib/models/hunter_model.dart
@@ -49,4 +49,16 @@ class HunterModel extends ChangeNotifier {
         .then((value) => notifyListeners())
         .catchError((error) => print("Failed to order quest: $error"));
   }
+
+  Future clearQuest() async {
+    final hunterRef = FirebaseFirestore.instance.collection('hunters').doc(hunter.id);
+    hunterRef.update({
+      'currentQuest': null,
+    })
+        .then((value) => notifyListeners())
+        .catchError((error) => print("Failed to clear quest: $error"));
+
+    hunter.currentQuest = null;
+    notifyListeners();
+  }
 }

--- a/lib/models/hunter_model.dart
+++ b/lib/models/hunter_model.dart
@@ -41,7 +41,7 @@ class HunterModel extends ChangeNotifier {
     } else {
       hunter.quests.add(questRef);
     }
-
+    notifyListeners();
     hunterRef.update({
       'currentQuest': questRef,
       'quests': FieldValue.arrayUnion(hunter.quests),

--- a/lib/models/quest.dart
+++ b/lib/models/quest.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 
 class Quest {
   Quest(DocumentSnapshot doc){
+    this.id = doc.id;
     this.title = doc.data()['title'];
     this.siteUrl = doc.data()['siteUrl'];
     this.imageUrl = doc.data()['imageUrl'];
@@ -9,6 +10,7 @@ class Quest {
     this.timeAve = doc.data()['timeAve'];
     this.tags = doc.data()['tags'];
   }
+  String id;
   String title;
   String siteUrl;
   String imageUrl;

--- a/lib/views/quest_detail_page.dart
+++ b/lib/views/quest_detail_page.dart
@@ -72,9 +72,9 @@ class QuestDetailPage extends StatelessWidget {
                 if (currentQuest.id == data.id) {
                   return FlatButton(
                     onPressed: () => context.read<HunterModel>().clearQuest(),
-                    color: Colors.red,
+                    color: Colors.greenAccent,
                     child: Text(
-                      'クリアした！',
+                      'クリアする',
                     ),
                   );
                 } else {

--- a/lib/views/quest_detail_page.dart
+++ b/lib/views/quest_detail_page.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:g_sui_hunter/models/hunter_model.dart';
 import 'package:g_sui_hunter/models/quest.dart';
@@ -64,15 +65,37 @@ class QuestDetailPage extends StatelessWidget {
               );
             }).toList(),
           ),
-          FlatButton(
-            onPressed: () => context.read<HunterModel>().orderQuest(data),
-            color: Theme.of(context).primaryColor,
-            child: Text(
-              'クエスト登録',
-              style: TextStyle(
-                color: Theme.of(context).primaryColor,
-              ),
-            ),
+          Selector<HunterModel, DocumentReference>(
+            selector: (context, model) => model.hunter.currentQuest,
+            builder: (context, currentQuest, child) {
+              if (currentQuest != null) {
+                if (currentQuest.id == data.id) {
+                  return FlatButton(
+                    onPressed: () => print('TODO: クエストクリア時の処理'), // TODO: クエストクリア時の処理
+                    color: Colors.red,
+                    child: Text(
+                      'クリアした！',
+                    ),
+                  );
+                } else {
+                  return FlatButton(
+                    onPressed: () => print('TODO: クエスト中のページに遷移する処理'), // TODO: クエスト中のページに遷移する処理
+                    color: Colors.grey,
+                    child: Text(
+                      '現在、別のクエスト中です',
+                    ),
+                  );
+                }
+              } else {
+                return FlatButton(
+                  onPressed: () => context.read<HunterModel>().orderQuest(data),
+                  color: Theme.of(context).primaryColor,
+                  child: Text(
+                    'クエスト登録',
+                  ),
+                );
+              }
+            },
           ),
         ],
       ),

--- a/lib/views/quest_detail_page.dart
+++ b/lib/views/quest_detail_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:g_sui_hunter/models/hunter_model.dart';
 import 'package:g_sui_hunter/models/quest.dart';
 import 'package:decoratable_text/decoratable_text.dart';
+import 'package:provider/provider.dart';
 
 class QuestDetailPage extends StatelessWidget {
   const QuestDetailPage({
@@ -63,7 +65,7 @@ class QuestDetailPage extends StatelessWidget {
             }).toList(),
           ),
           FlatButton(
-            onPressed: null, //TODO: クエスト登録を押したときに実行される関数の作成
+            onPressed: () => context.read<HunterModel>().orderQuest(data),
             color: Theme.of(context).primaryColor,
             child: Text(
               'クエスト登録',

--- a/lib/views/quest_detail_page.dart
+++ b/lib/views/quest_detail_page.dart
@@ -71,7 +71,7 @@ class QuestDetailPage extends StatelessWidget {
               if (currentQuest != null) {
                 if (currentQuest.id == data.id) {
                   return FlatButton(
-                    onPressed: () => print('TODO: クエストクリア時の処理'), // TODO: クエストクリア時の処理
+                    onPressed: () => context.read<HunterModel>().clearQuest(),
                     color: Colors.red,
                     child: Text(
                       'クリアした！',

--- a/lib/views/quest_detail_page.dart
+++ b/lib/views/quest_detail_page.dart
@@ -79,7 +79,16 @@ class QuestDetailPage extends StatelessWidget {
                   );
                 } else {
                   return FlatButton(
-                    onPressed: () => print('TODO: クエスト中のページに遷移する処理'), // TODO: クエスト中のページに遷移する処理
+                    onPressed: () async {
+                      Navigator.pop(context);
+                      final currentQuestData =  Quest(await currentQuest.get());
+                      await Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => QuestDetailPage(data: currentQuestData),
+                        ),
+                      );
+                    },
                     color: Colors.grey,
                     child: Text(
                       '現在、別のクエスト中です',

--- a/lib/views/quest_list_page.dart
+++ b/lib/views/quest_list_page.dart
@@ -1,5 +1,7 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:g_sui_hunter/models/hunter_model.dart';
 import 'package:g_sui_hunter/models/quest.dart';
 import 'package:g_sui_hunter/models/user_auth_model.dart';
 import 'package:provider/provider.dart';
@@ -39,7 +41,16 @@ class QuestListPage extends StatelessWidget {
                       minWidth: 40.0,
                       height: 20.0,
                       child:  RaisedButton(
-                        child: Text("クエスト受注中"),
+                        child: Selector<HunterModel, DocumentReference>(
+                          selector: (context, model) => model.hunter.currentQuest,
+                          builder: (context, currentQuest, child) {
+                            if (currentQuest == null) {
+                              return Text("クエスト未選択");
+                            } else {
+                              return Text("クエスト中");
+                            }
+                          },
+                        ),
                       ),
                     ),
                   ),


### PR DESCRIPTION
### やったこと
- 「クエスト登録」でhunterのcurrentQuestにquestを設定
- 「クエストクリア」でhunterのcurrentQuestをnullに設定
- 「現在、他のクエスト中」で受注中のクエスト詳細ページに遷移
-  上記の状態が変更が変わったのに合わせて、クエスト一覧右上のテキストやボタンの色などの描画が反映される

### 画面
1. クエスト登録
<img src='https://user-images.githubusercontent.com/39556764/101456384-4f582400-3977-11eb-9a90-dfb6d9339e67.png' height='400'>

2. クエストクリア
<img src='https://user-images.githubusercontent.com/39556764/101456347-45362580-3977-11eb-9d45-4da5447f2aef.png' height='400'>

3. 現在、別のクエスト中
<img src='https://user-images.githubusercontent.com/39556764/101456321-3b142700-3977-11eb-923f-3e2c8743bb79.png'  height='400'>