### PR TITLE
ハンターのランクに合わせてクエストを表示

### DIFF
--- a/lib/models/quest_model.dart
+++ b/lib/models/quest_model.dart
@@ -6,7 +6,7 @@ class QuestModel extends ChangeNotifier {
   List<Quest> questList = [];
 
   void fetchQuest() async {
-    final QuerySnapshot questSnapshots = await FirebaseFirestore.instance.collection('quests').get();
+    final QuerySnapshot questSnapshots = await FirebaseFirestore.instance.collection('quests').orderBy('rank').get();
     final questList = questSnapshots.docs.map((doc) => Quest(doc)).toList();
     this.questList = questList;
     notifyListeners();

--- a/lib/views/widgets/quest_card.dart
+++ b/lib/views/widgets/quest_card.dart
@@ -13,33 +13,53 @@ class QuestCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () {
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (context) => QuestDetailPage(data: data),
-          ),
-        );
-      },
-      child: Card(
-        child: Column(
-          children: [
-            ListTile(
-              title: Text(data.title),
-            ),
-            Expanded(
-              child: Center(
-                child: CachedNetworkImage(
-                  placeholder: (context, url) => CircularProgressIndicator(),
-                  imageUrl: data.imageUrl,
-                  errorWidget: (context, url, error) => Icon(Icons.error),
-                ),
+    return Stack(
+      children: [
+        GestureDetector(
+          onTap: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (context) => QuestDetailPage(data: data),
               ),
+            );
+          },
+          child: Card(
+            child: Column(
+              children: [
+                ListTile(
+                  title: Text(data.title),
+                ),
+                Expanded(
+                  child: Center(
+                    child: CachedNetworkImage(
+                      placeholder: (context, url) => CircularProgressIndicator(),
+                      imageUrl: data.imageUrl,
+                      errorWidget: (context, url, error) => Icon(Icons.error),
+                    ),
+                  ),
+                ),
+              ],
             ),
-          ],
+          ),
         ),
-      ),
+        Opacity(
+          opacity: 0.8,
+          child: Container(
+            alignment: Alignment.center,
+            color: Colors.grey,
+            child: LayoutBuilder(
+              builder: (BuildContext context, BoxConstraints constraints) {
+                return Icon(
+                  Icons.lock,
+                  color: Colors.yellow,
+                  size: constraints.maxWidth * 0.5,
+                );
+              },
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/views/widgets/quest_card.dart
+++ b/lib/views/widgets/quest_card.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:g_sui_hunter/models/hunter_model.dart';
 import 'package:g_sui_hunter/models/quest.dart';
 import 'package:g_sui_hunter/views/quest_detail_page.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:provider/provider.dart';
 
 class QuestCard extends StatelessWidget {
   const QuestCard({
@@ -43,21 +45,30 @@ class QuestCard extends StatelessWidget {
             ),
           ),
         ),
-        Opacity(
-          opacity: 0.8,
-          child: Container(
-            alignment: Alignment.center,
-            color: Colors.grey,
-            child: LayoutBuilder(
-              builder: (BuildContext context, BoxConstraints constraints) {
-                return Icon(
-                  Icons.lock,
-                  color: Colors.yellow,
-                  size: constraints.maxWidth * 0.5,
-                );
-              },
-            ),
-          ),
+        Selector<HunterModel, int>(
+          selector: (context, model) => model.hunter.rank,
+          builder: (context, rank, child) {
+            if (rank >= data.rank) {
+              return Container();
+            } else {
+              return Opacity(
+                opacity: 0.8,
+                child: Container(
+                  alignment: Alignment.center,
+                  color: Colors.grey,
+                  child: LayoutBuilder(
+                    builder: (BuildContext context, BoxConstraints constraints) {
+                      return Icon(
+                        Icons.lock,
+                        color: Colors.yellow,
+                        size: constraints.maxWidth * 0.5,
+                      );
+                    },
+                  ),
+                ),
+              );
+            }
+          },
         ),
       ],
     );

--- a/lib/views/widgets/quest_card.dart
+++ b/lib/views/widgets/quest_card.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:g_sui_hunter/models/hunter_model.dart';
 import 'package:g_sui_hunter/models/quest.dart';
@@ -51,19 +52,36 @@ class QuestCard extends StatelessWidget {
             if (rank >= data.rank) {
               return Container();
             } else {
-              return Opacity(
-                opacity: 0.8,
-                child: Container(
-                  alignment: Alignment.center,
-                  color: Colors.grey,
-                  child: LayoutBuilder(
-                    builder: (BuildContext context, BoxConstraints constraints) {
-                      return Icon(
-                        Icons.lock,
-                        color: Colors.yellow,
-                        size: constraints.maxWidth * 0.5,
-                      );
-                    },
+              return GestureDetector(
+                onTap: () => showDialog(
+                  context: context,
+                  builder: (context) {
+                    return CupertinoAlertDialog(
+                      title: Text('挑戦できません'),
+                      content: Text('これはRank${data.rank}のクエストです'),
+                      actions: [
+                        CupertinoDialogAction(
+                          child: Text('OK'),
+                          onPressed: () => Navigator.pop(context),
+                        ),
+                      ],
+                    );
+                  },
+                ),
+                child: Opacity(
+                  opacity: 0.8,
+                  child: Container(
+                    alignment: Alignment.center,
+                    color: Colors.grey,
+                    child: LayoutBuilder(
+                      builder: (BuildContext context, BoxConstraints constraints) {
+                        return Icon(
+                          Icons.lock,
+                          color: Colors.yellow,
+                          size: constraints.maxWidth * 0.5,
+                        );
+                      },
+                    ),
                   ),
                 ),
               );


### PR DESCRIPTION
### やったこと
- ハンターのランクに合わせて受注可能なクエストを表示
- ランクが足りてないものはロックした
- ロックされているものをタップすれば警告を表示

### 画面
- ランクが足りないものはロック
<img src='https://user-images.githubusercontent.com/39556764/101480842-9229f400-3997-11eb-8c2c-0e389b226cd0.png' height='400'>

- 挑戦不可のダイアログ
<img src='https://user-images.githubusercontent.com/39556764/101480825-8b02e600-3997-11eb-9e7f-089a5dafef86.png' height='400'>
