### PR TITLE
クエストクリア画面を追加

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:g_sui_hunter/models/user_auth_model.dart';
 import 'package:g_sui_hunter/models/hunter_model.dart';
 import 'package:g_sui_hunter/models/quest_model.dart';
 import 'package:g_sui_hunter/views/add_quest_page.dart';
+import 'package:g_sui_hunter/views/add_result_page.dart';
 import 'package:g_sui_hunter/views/root_page.dart';
 import 'package:provider/provider.dart';
 
@@ -42,6 +43,7 @@ class MyApp extends StatelessWidget {
         routes: {
           '/': (BuildContext context) => RootPage(),
           '/add_quest': (BuildContext context) => AddQuestPage(),
+          '/add_result': (BuildContext context) => AddResultPage(),
         },
       ),
     );

--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -1,0 +1,22 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:g_sui_hunter/models/hunter.dart';
+
+class AddResultModel extends ChangeNotifier {
+  Hunter hunter;
+
+  Future clearQuest() async {
+    final hunterRef = FirebaseFirestore.instance.collection('hunters').doc(hunter.id);
+    hunterRef.update({
+      'currentQuest': null,
+    });
+    hunter.currentQuest = null;
+    notifyListeners();
+  }
+
+  Future createState(Hunter hunter) async {
+    this.hunter = hunter;
+    notifyListeners();
+  }
+
+}

--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -1,9 +1,11 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:g_sui_hunter/models/hunter.dart';
+import 'package:g_sui_hunter/models/quest.dart';
 
 class AddResultModel extends ChangeNotifier {
   Hunter hunter;
+  Quest currentQuest;
 
   Future clearQuest() async {
     final hunterRef = FirebaseFirestore.instance.collection('hunters').doc(hunter.id);
@@ -16,6 +18,10 @@ class AddResultModel extends ChangeNotifier {
 
   Future createState(Hunter hunter) async {
     this.hunter = hunter;
+
+    final questSnapshot = await hunter.currentQuest.get();
+    this.currentQuest = Quest(questSnapshot);
+
     notifyListeners();
   }
 

--- a/lib/models/hunter_model.dart
+++ b/lib/models/hunter_model.dart
@@ -36,15 +36,9 @@ class HunterModel extends ChangeNotifier {
     final questRef = FirebaseFirestore.instance.collection('quests').doc(data.id);
 
     hunter.currentQuest  = questRef;
-    if (hunter.quests == null) {
-      hunter.quests = [questRef];
-    } else {
-      hunter.quests.add(questRef);
-    }
     notifyListeners();
     hunterRef.update({
       'currentQuest': questRef,
-      'quests': FieldValue.arrayUnion(hunter.quests),
     })
         .then((value) => notifyListeners())
         .catchError((error) => print("Failed to order quest: $error"));

--- a/lib/views/add_result_page.dart
+++ b/lib/views/add_result_page.dart
@@ -1,53 +1,62 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:g_sui_hunter/models/add_result_model.dart';
+import 'package:g_sui_hunter/models/hunter_model.dart';
 import 'package:g_sui_hunter/views/widgets/clear_comment_form.dart';
 import 'package:g_sui_hunter/views/widgets/clear_quest_button.dart';
 import 'package:g_sui_hunter/views/widgets/clear_quest_image.dart';
 import 'package:g_sui_hunter/views/widgets/clear_quest_info.dart';
 import 'package:g_sui_hunter/views/widgets/clear_time_form.dart';
+import 'package:provider/provider.dart';
 
 class AddResultPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text('クエスト結果'),
-      ),
-      body: SingleChildScrollView(
-        child: SizedBox(
-          height: MediaQuery.of(context).size.height -
-              AppBar().preferredSize.height -
-              MediaQuery.of(context).padding.top,
-          child: Column(
-            children: [
-              Expanded(
-                flex: 4,
-                child: Row(
-                  children: [
-                    Expanded(
-                      flex: 1,
-                      child: ClearQuestInfo(),
-                    ),
-                    Expanded(
-                      flex: 1,
-                      child: ClearQuestImage(),
-                    ),
-                  ],
+    return ChangeNotifierProvider<AddResultModel>(
+      create: (_) {
+        final hunter = context.read<HunterModel>().hunter;
+        return AddResultModel()..createState(hunter);
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text('クエスト結果'),
+        ),
+        body: SingleChildScrollView(
+          child: SizedBox(
+            height: MediaQuery.of(context).size.height -
+                AppBar().preferredSize.height -
+                MediaQuery.of(context).padding.top,
+            child: Column(
+              children: [
+                Expanded(
+                  flex: 4,
+                  child: Row(
+                    children: [
+                      Expanded(
+                        flex: 1,
+                        child: ClearQuestInfo(),
+                      ),
+                      Expanded(
+                        flex: 1,
+                        child: ClearQuestImage(),
+                      ),
+                    ],
+                  ),
                 ),
-              ),
-              Expanded(
-                flex: 2,
-                child: ClearTimeForm(),
-              ),
-              Expanded(
-                flex: 3,
-                child: ClearCommentForm(),
-              ),
-              Expanded(
-                flex: 1,
-                child: ClearQuestButton(),
-              ),
-            ],
+                Expanded(
+                  flex: 2,
+                  child: ClearTimeForm(),
+                ),
+                Expanded(
+                  flex: 3,
+                  child: ClearCommentForm(),
+                ),
+                Expanded(
+                  flex: 1,
+                  child: ClearQuestButton(),
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/views/add_result_page.dart
+++ b/lib/views/add_result_page.dart
@@ -1,9 +1,9 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
-import 'package:auto_size_text/auto_size_text.dart';
 import 'package:g_sui_hunter/views/widgets/clear_comment_form.dart';
 import 'package:g_sui_hunter/views/widgets/clear_quest_button.dart';
+import 'package:g_sui_hunter/views/widgets/clear_quest_info.dart';
 import 'package:g_sui_hunter/views/widgets/clear_time_form.dart';
 
 class AddResultPage extends StatelessWidget {
@@ -26,38 +26,7 @@ class AddResultPage extends StatelessWidget {
                   children: [
                     Expanded(
                       flex: 1,
-                      child: LayoutBuilder(
-                        builder: (BuildContext context, BoxConstraints constraints) {
-                          return Column(
-                            mainAxisAlignment: MainAxisAlignment.spaceAround,
-                            children: [
-                              Text(
-                                'Rank0',
-                                style: TextStyle(
-                                  fontSize: constraints.maxHeight * 0.1,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                              ),
-                              AutoSizeText(
-                                'デミグラスハンバーグ',
-                                style: TextStyle(
-                                  fontSize: constraints.maxHeight * 0.2,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                                maxLines: 2,
-                                textAlign: TextAlign.center,
-                              ),
-                              Text(
-                                'をクリア！',
-                                style: TextStyle(
-                                  fontSize: constraints.maxHeight * 0.1,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                              ),
-                            ],
-                          );
-                        },
-                      ),
+                      child: ClearQuestInfo(),
                     ),
                     Expanded(
                       flex: 1,

--- a/lib/views/add_result_page.dart
+++ b/lib/views/add_result_page.dart
@@ -10,135 +10,142 @@ class AddResultPage extends StatelessWidget {
       appBar: AppBar(
         title: Text('クエスト結果'),
       ),
-      body: Column(
-        children: [
-          Expanded(
-            flex: 4,
-            child: Row(
-              children: [
-                Expanded(
-                  flex: 1,
-                  child: LayoutBuilder(
-                    builder: (BuildContext context, BoxConstraints constraints) {
-                      return Column(
-                        mainAxisAlignment: MainAxisAlignment.spaceAround,
-                        children: [
-                          Text(
-                            'Rank0',
-                            style: TextStyle(
-                              fontSize: constraints.maxHeight * 0.1,
-                              fontWeight: FontWeight.bold,
-                            ),
+      body: SingleChildScrollView(
+        child: SizedBox(
+          height: MediaQuery.of(context).size.height -
+              AppBar().preferredSize.height -
+              MediaQuery.of(context).padding.top,
+          child: Column(
+            children: [
+              Expanded(
+                flex: 4,
+                child: Row(
+                  children: [
+                    Expanded(
+                      flex: 1,
+                      child: LayoutBuilder(
+                        builder: (BuildContext context, BoxConstraints constraints) {
+                          return Column(
+                            mainAxisAlignment: MainAxisAlignment.spaceAround,
+                            children: [
+                              Text(
+                                'Rank0',
+                                style: TextStyle(
+                                  fontSize: constraints.maxHeight * 0.1,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                              AutoSizeText(
+                                'デミグラスハンバーグ',
+                                style: TextStyle(
+                                  fontSize: constraints.maxHeight * 0.2,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                                maxLines: 2,
+                                textAlign: TextAlign.center,
+                              ),
+                              Text(
+                                'をクリア！',
+                                style: TextStyle(
+                                  fontSize: constraints.maxHeight * 0.1,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                            ],
+                          );
+                        },
+                      ),
+                    ),
+                    Expanded(
+                      flex: 1,
+                      child: Container(
+                        alignment: Alignment.center,
+                        color: Colors.orange,
+                        child: FittedBox(
+                          fit: BoxFit.contain,
+                          child: CachedNetworkImage(
+                            placeholder: (context, url) => CircularProgressIndicator(),
+                            imageUrl: '',
+                            errorWidget: (context, url, error) => Icon(Icons.error),
                           ),
-                          AutoSizeText(
-                            'デミグラスハンバーグ',
-                            style: TextStyle(
-                              fontSize: constraints.maxHeight * 0.2,
-                              fontWeight: FontWeight.bold,
-                            ),
-                            maxLines: 2,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Expanded(
+                flex: 2,
+                child: Padding(
+                  padding: EdgeInsets.all(10),
+                  child:  Row(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      Text(
+                        'クリアタイム',
+                        style: TextStyle(
+                          fontSize: 20,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      Flexible(
+                        child: Padding(
+                          padding: EdgeInsets.fromLTRB(20, 0, 20, 0),
+                          child: TextField(
                             textAlign: TextAlign.center,
                           ),
-                          Text(
-                            'をクリア！',
-                            style: TextStyle(
-                              fontSize: constraints.maxHeight * 0.1,
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                        ],
-                      );
-                    },
+                        ),
+                      ),
+                      Text(
+                        '分',
+                        style: TextStyle(
+                          fontSize: 20,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ],
                   ),
                 ),
-                Expanded(
-                  flex: 1,
-                  child: Container(
-                    alignment: Alignment.center,
-                    color: Colors.orange,
-                    child: FittedBox(
-                      fit: BoxFit.contain,
-                      child: CachedNetworkImage(
-                        placeholder: (context, url) => CircularProgressIndicator(),
-                        imageUrl: '',
-                        errorWidget: (context, url, error) => Icon(Icons.error),
+              ),
+              Expanded(
+                flex: 3,
+                child: Padding(
+                  padding: EdgeInsets.all(10),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('コメント'),
+                      TextField(
+                        keyboardType: TextInputType.multiline,
+                        decoration: InputDecoration(
+                          hintText: 'クリアのコツや感想を教えてください',
+                          border: OutlineInputBorder(),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              Expanded(
+                flex: 1,
+                child: Container(
+                  alignment: Alignment.center,
+                  child: FlatButton(
+                    color: Colors.green,
+                    child: Text(
+                      'クエストクリア',
+                      style: TextStyle(
+                        color: Colors.white,
                       ),
                     ),
+                    onPressed: () => print('クエスト完了の処理'), // TODO: クエスト完了の処理
                   ),
                 ),
-              ],
-            ),
-          ),
-          Expanded(
-            flex: 2,
-            child: Padding(
-              padding: EdgeInsets.all(10),
-              child:  Row(
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  Text(
-                    'クリアタイム',
-                    style: TextStyle(
-                      fontSize: 20,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                  Flexible(
-                    child: Padding(
-                      padding: EdgeInsets.fromLTRB(20, 0, 20, 0),
-                      child: TextField(
-                        textAlign: TextAlign.center,
-                      ),
-                    ),
-                  ),
-                  Text(
-                    '分',
-                    style: TextStyle(
-                      fontSize: 20,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ],
               ),
-            ),
+            ],
           ),
-          Expanded(
-            flex: 3,
-            child: Padding(
-              padding: EdgeInsets.all(10),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text('コメント'),
-                  TextField(
-                    keyboardType: TextInputType.multiline,
-                    decoration: InputDecoration(
-                      hintText: 'クリアのコツや感想を教えてください',
-                      border: OutlineInputBorder(),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-          Expanded(
-            flex: 1,
-            child: Container(
-              alignment: Alignment.center,
-              child: FlatButton(
-                color: Colors.green,
-                child: Text(
-                  'クエストクリア',
-                  style: TextStyle(
-                    color: Colors.white,
-                  ),
-                ),
-                onPressed: () => print('クエスト完了の処理'), // TODO: クエスト完了の処理
-              ),
-            ),
-          ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/views/add_result_page.dart
+++ b/lib/views/add_result_page.dart
@@ -12,8 +12,21 @@ class AddResultPage extends StatelessWidget {
         children: [
           Expanded(
             flex: 4,
-            child: Container(
-              color: Colors.blue,
+            child: Row(
+              children: [
+                Expanded(
+                  flex: 1,
+                  child: Container(
+                    color: Colors.orange,
+                  ),
+                ),
+                Expanded(
+                  flex: 1,
+                  child: Container(
+                    color: Colors.blue,
+                  ),
+                ),
+              ],
             ),
           ),
           Expanded(

--- a/lib/views/add_result_page.dart
+++ b/lib/views/add_result_page.dart
@@ -23,13 +23,28 @@ class AddResultPage extends StatelessWidget {
               child:  Row(
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
-                  Text('クリアタイム'),
-                  Flexible(
-                    child: TextField(
-                      textAlign: TextAlign.center,
+                  Text(
+                    'クリアタイム',
+                    style: TextStyle(
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
                     ),
                   ),
-                  Text('分')
+                  Flexible(
+                    child: Padding(
+                      padding: EdgeInsets.fromLTRB(20, 0, 20, 0),
+                      child: TextField(
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ),
+                  Text(
+                    '分',
+                    style: TextStyle(
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
                 ],
               ),
             ),

--- a/lib/views/add_result_page.dart
+++ b/lib/views/add_result_page.dart
@@ -3,8 +3,38 @@ import 'package:flutter/material.dart';
 class AddResultPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Container(
-      color: Colors.blue,
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('クエスト結果'),
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            flex: 4,
+            child: Container(
+              color: Colors.blue,
+            ),
+          ),
+          Expanded(
+            flex: 2,
+            child: Container(
+              color: Colors.red,
+            ),
+          ),
+          Expanded(
+            flex: 3,
+            child: Container(
+              color: Colors.orange,
+            ),
+          ),
+          Expanded(
+            flex: 1,
+            child: Container(
+              color: Colors.green,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/views/add_result_page.dart
+++ b/lib/views/add_result_page.dart
@@ -1,8 +1,8 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:g_sui_hunter/views/widgets/clear_comment_form.dart';
 import 'package:g_sui_hunter/views/widgets/clear_quest_button.dart';
+import 'package:g_sui_hunter/views/widgets/clear_quest_image.dart';
 import 'package:g_sui_hunter/views/widgets/clear_quest_info.dart';
 import 'package:g_sui_hunter/views/widgets/clear_time_form.dart';
 
@@ -30,31 +30,7 @@ class AddResultPage extends StatelessWidget {
                     ),
                     Expanded(
                       flex: 1,
-                      child: Container(
-                        margin: EdgeInsets.all(8),
-                        padding: EdgeInsets.all(8),
-                        decoration: BoxDecoration(
-                          color: Colors.orange,
-                          borderRadius: BorderRadius.circular(10),
-                          boxShadow: [
-                            BoxShadow(
-                              color: Colors.black26,
-                              spreadRadius: 1.0,
-                              blurRadius: 10.0,
-                              offset: Offset(10, 10),
-                            ),
-                          ],
-                        ),
-                        alignment: Alignment.center,
-                        child: FittedBox(
-                          fit: BoxFit.contain,
-                          child: CachedNetworkImage(
-                            placeholder: (context, url) => CircularProgressIndicator(),
-                            imageUrl: '',
-                            errorWidget: (context, url, error) => Icon(Icons.error),
-                          ),
-                        ),
-                      ),
+                      child: ClearQuestImage(),
                     ),
                   ],
                 ),

--- a/lib/views/add_result_page.dart
+++ b/lib/views/add_result_page.dart
@@ -92,6 +92,7 @@ class AddResultPage extends StatelessWidget {
                         child: Padding(
                           padding: EdgeInsets.fromLTRB(20, 0, 20, 0),
                           child: TextField(
+                            keyboardType: TextInputType.number,
                             textAlign: TextAlign.center,
                           ),
                         ),

--- a/lib/views/add_result_page.dart
+++ b/lib/views/add_result_page.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class AddResultPage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.blue,
+    );
+  }
+}

--- a/lib/views/add_result_page.dart
+++ b/lib/views/add_result_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:g_sui_hunter/models/add_result_model.dart';
 import 'package:g_sui_hunter/models/hunter_model.dart';
+import 'package:g_sui_hunter/models/quest.dart';
 import 'package:g_sui_hunter/views/widgets/clear_comment_form.dart';
 import 'package:g_sui_hunter/views/widgets/clear_quest_button.dart';
 import 'package:g_sui_hunter/views/widgets/clear_quest_image.dart';
@@ -17,49 +18,56 @@ class AddResultPage extends StatelessWidget {
         final hunter = context.read<HunterModel>().hunter;
         return AddResultModel()..createState(hunter);
       },
-      child: Scaffold(
-        appBar: AppBar(
-          title: Text('クエスト結果'),
-        ),
-        body: SingleChildScrollView(
-          child: SizedBox(
-            height: MediaQuery.of(context).size.height -
-                AppBar().preferredSize.height -
-                MediaQuery.of(context).padding.top,
-            child: Column(
-              children: [
-                Expanded(
-                  flex: 4,
-                  child: Row(
-                    children: [
-                      Expanded(
-                        flex: 1,
-                        child: ClearQuestInfo(),
-                      ),
-                      Expanded(
-                        flex: 1,
-                        child: ClearQuestImage(),
-                      ),
-                    ],
+      builder: (context, child) {
+        final currentQuest = context.select<AddResultModel, Quest>((model) => model.currentQuest);
+        return Scaffold(
+          appBar: AppBar(
+            title: Text('クエスト結果'),
+          ),
+          body: currentQuest == null ?
+          Center(
+            child: CircularProgressIndicator(),
+          ) :
+          SingleChildScrollView(
+            child: SizedBox(
+              height: MediaQuery.of(context).size.height -
+                  AppBar().preferredSize.height -
+                  MediaQuery.of(context).padding.top,
+              child: Column(
+                children: [
+                  Expanded(
+                    flex: 4,
+                    child: Row(
+                      children: [
+                        Expanded(
+                          flex: 1,
+                          child: ClearQuestInfo(),
+                        ),
+                        Expanded(
+                          flex: 1,
+                          child: ClearQuestImage(),
+                        ),
+                      ],
+                    ),
                   ),
-                ),
-                Expanded(
-                  flex: 2,
-                  child: ClearTimeForm(),
-                ),
-                Expanded(
-                  flex: 3,
-                  child: ClearCommentForm(),
-                ),
-                Expanded(
-                  flex: 1,
-                  child: ClearQuestButton(),
-                ),
-              ],
+                  Expanded(
+                    flex: 2,
+                    child: ClearTimeForm(),
+                  ),
+                  Expanded(
+                    flex: 3,
+                    child: ClearCommentForm(),
+                  ),
+                  Expanded(
+                    flex: 1,
+                    child: ClearQuestButton(),
+                  ),
+                ],
+              ),
             ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/views/add_result_page.dart
+++ b/lib/views/add_result_page.dart
@@ -2,6 +2,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:auto_size_text/auto_size_text.dart';
+import 'package:g_sui_hunter/views/widgets/clear_time_form.dart';
 
 class AddResultPage extends StatelessWidget {
   @override
@@ -89,37 +90,7 @@ class AddResultPage extends StatelessWidget {
               ),
               Expanded(
                 flex: 2,
-                child: Padding(
-                  padding: EdgeInsets.all(10),
-                  child:  Row(
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      Text(
-                        'クリアタイム',
-                        style: TextStyle(
-                          fontSize: 20,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                      Flexible(
-                        child: Padding(
-                          padding: EdgeInsets.fromLTRB(20, 0, 20, 0),
-                          child: TextField(
-                            keyboardType: TextInputType.number,
-                            textAlign: TextAlign.center,
-                          ),
-                        ),
-                      ),
-                      Text(
-                        '分',
-                        style: TextStyle(
-                          fontSize: 20,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
+                child: ClearTimeForm(),
               ),
               Expanded(
                 flex: 3,

--- a/lib/views/add_result_page.dart
+++ b/lib/views/add_result_page.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:auto_size_text/auto_size_text.dart';
@@ -53,7 +54,16 @@ class AddResultPage extends StatelessWidget {
                 Expanded(
                   flex: 1,
                   child: Container(
-                    color: Colors.blue,
+                    alignment: Alignment.center,
+                    color: Colors.orange,
+                    child: FittedBox(
+                      fit: BoxFit.contain,
+                      child: CachedNetworkImage(
+                        placeholder: (context, url) => CircularProgressIndicator(),
+                        imageUrl: '',
+                        errorWidget: (context, url, error) => Icon(Icons.error),
+                      ),
+                    ),
                   ),
                 ),
               ],

--- a/lib/views/add_result_page.dart
+++ b/lib/views/add_result_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
 class AddResultPage extends StatelessWidget {
   @override
@@ -17,8 +18,20 @@ class AddResultPage extends StatelessWidget {
           ),
           Expanded(
             flex: 2,
-            child: Container(
-              color: Colors.red,
+            child: Padding(
+              padding: EdgeInsets.all(10),
+              child:  Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Text('クリアタイム'),
+                  Flexible(
+                    child: TextField(
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                  Text('分')
+                ],
+              ),
             ),
           ),
           Expanded(

--- a/lib/views/add_result_page.dart
+++ b/lib/views/add_result_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:auto_size_text/auto_size_text.dart';
 
 class AddResultPage extends StatelessWidget {
   @override
@@ -16,8 +17,37 @@ class AddResultPage extends StatelessWidget {
               children: [
                 Expanded(
                   flex: 1,
-                  child: Container(
-                    color: Colors.orange,
+                  child: LayoutBuilder(
+                    builder: (BuildContext context, BoxConstraints constraints) {
+                      return Column(
+                        mainAxisAlignment: MainAxisAlignment.spaceAround,
+                        children: [
+                          Text(
+                            'Rank0',
+                            style: TextStyle(
+                              fontSize: constraints.maxHeight * 0.1,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          AutoSizeText(
+                            'デミグラスハンバーグ',
+                            style: TextStyle(
+                              fontSize: constraints.maxHeight * 0.2,
+                              fontWeight: FontWeight.bold,
+                            ),
+                            maxLines: 2,
+                            textAlign: TextAlign.center,
+                          ),
+                          Text(
+                            'をクリア！',
+                            style: TextStyle(
+                              fontSize: constraints.maxHeight * 0.1,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ],
+                      );
+                    },
                   ),
                 ),
                 Expanded(

--- a/lib/views/add_result_page.dart
+++ b/lib/views/add_result_page.dart
@@ -2,6 +2,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:auto_size_text/auto_size_text.dart';
+import 'package:g_sui_hunter/views/widgets/clear_comment_form.dart';
 import 'package:g_sui_hunter/views/widgets/clear_time_form.dart';
 
 class AddResultPage extends StatelessWidget {
@@ -94,23 +95,7 @@ class AddResultPage extends StatelessWidget {
               ),
               Expanded(
                 flex: 3,
-                child: Padding(
-                  padding: EdgeInsets.all(10),
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text('コメント'),
-                      TextField(
-                        keyboardType: TextInputType.multiline,
-                        decoration: InputDecoration(
-                          hintText: 'クリアのコツや感想を教えてください',
-                          border: OutlineInputBorder(),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
+                child: ClearCommentForm(),
               ),
               Expanded(
                 flex: 1,

--- a/lib/views/add_result_page.dart
+++ b/lib/views/add_result_page.dart
@@ -23,8 +23,22 @@ class AddResultPage extends StatelessWidget {
           ),
           Expanded(
             flex: 3,
-            child: Container(
-              color: Colors.orange,
+            child: Padding(
+              padding: EdgeInsets.all(10),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('コメント'),
+                  TextField(
+                    keyboardType: TextInputType.multiline,
+                    decoration: InputDecoration(
+                      hintText: 'クリアのコツや感想を教えてください',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
           Expanded(

--- a/lib/views/add_result_page.dart
+++ b/lib/views/add_result_page.dart
@@ -30,7 +30,17 @@ class AddResultPage extends StatelessWidget {
           Expanded(
             flex: 1,
             child: Container(
-              color: Colors.green,
+              alignment: Alignment.center,
+              child: FlatButton(
+                color: Colors.green,
+                child: Text(
+                  'クエストクリア',
+                  style: TextStyle(
+                    color: Colors.white,
+                  ),
+                ),
+                onPressed: () => print('クエスト完了の処理'), // TODO: クエスト完了の処理
+              ),
             ),
           ),
         ],

--- a/lib/views/add_result_page.dart
+++ b/lib/views/add_result_page.dart
@@ -59,8 +59,21 @@ class AddResultPage extends StatelessWidget {
                     Expanded(
                       flex: 1,
                       child: Container(
+                        margin: EdgeInsets.all(8),
+                        padding: EdgeInsets.all(8),
+                        decoration: BoxDecoration(
+                          color: Colors.orange,
+                          borderRadius: BorderRadius.circular(10),
+                          boxShadow: [
+                            BoxShadow(
+                              color: Colors.black26,
+                              spreadRadius: 1.0,
+                              blurRadius: 10.0,
+                              offset: Offset(10, 10),
+                            ),
+                          ],
+                        ),
                         alignment: Alignment.center,
-                        color: Colors.orange,
                         child: FittedBox(
                           fit: BoxFit.contain,
                           child: CachedNetworkImage(

--- a/lib/views/add_result_page.dart
+++ b/lib/views/add_result_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:g_sui_hunter/views/widgets/clear_comment_form.dart';
+import 'package:g_sui_hunter/views/widgets/clear_quest_button.dart';
 import 'package:g_sui_hunter/views/widgets/clear_time_form.dart';
 
 class AddResultPage extends StatelessWidget {
@@ -99,19 +100,7 @@ class AddResultPage extends StatelessWidget {
               ),
               Expanded(
                 flex: 1,
-                child: Container(
-                  alignment: Alignment.center,
-                  child: FlatButton(
-                    color: Colors.green,
-                    child: Text(
-                      'クエストクリア',
-                      style: TextStyle(
-                        color: Colors.white,
-                      ),
-                    ),
-                    onPressed: () => print('クエスト完了の処理'), // TODO: クエスト完了の処理
-                  ),
-                ),
+                child: ClearQuestButton(),
               ),
             ],
           ),

--- a/lib/views/quest_detail_page.dart
+++ b/lib/views/quest_detail_page.dart
@@ -90,7 +90,10 @@ class QuestDetailPage extends StatelessWidget {
                             ),
                             CupertinoDialogAction(
                               child: Text('Get！'),
-                              onPressed: () => Navigator.pop(context),
+                              onPressed: () async {
+                                await Navigator.pushNamed(context, '/add_result');
+                                Navigator.pop(context);
+                              },
                             ),
                           ],
                         );

--- a/lib/views/quest_detail_page.dart
+++ b/lib/views/quest_detail_page.dart
@@ -91,8 +91,8 @@ class QuestDetailPage extends StatelessWidget {
                             CupertinoDialogAction(
                               child: Text('Get！'),
                               onPressed: () async {
-                                await Navigator.pushNamed(context, '/add_result');
                                 Navigator.pop(context);
+                                await Navigator.pushNamed(context, '/add_result');
                               },
                             ),
                           ],

--- a/lib/views/quest_detail_page.dart
+++ b/lib/views/quest_detail_page.dart
@@ -85,7 +85,6 @@ class QuestDetailPage extends StatelessWidget {
                 } else {
                   return FlatButton(
                     onPressed: () async {
-                      Navigator.pop(context);
                       final currentQuestData =  Quest(await currentQuest.get());
                       await Navigator.push(
                         context,
@@ -93,6 +92,7 @@ class QuestDetailPage extends StatelessWidget {
                           builder: (context) => QuestDetailPage(data: currentQuestData),
                         ),
                       );
+                      Navigator.pop(context);
                     },
                     color: Colors.grey,
                     child: Text(

--- a/lib/views/quest_detail_page.dart
+++ b/lib/views/quest_detail_page.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:g_sui_hunter/models/hunter_model.dart';
 import 'package:g_sui_hunter/models/quest.dart';
@@ -76,7 +77,25 @@ class QuestDetailPage extends StatelessWidget {
               if (currentQuest != null) {
                 if (currentQuest.id == data.id) {
                   return FlatButton(
-                    onPressed: () => context.read<HunterModel>().clearQuest(),
+                    onPressed: () => showDialog(
+                      context: context,
+                      builder: (context) {
+                        return CupertinoAlertDialog(
+                          title: Text('ナイス自炊！'),
+                          content: Text('結果を報告して自炊ポイントをGet'),
+                          actions: [
+                            CupertinoDialogAction(
+                              child: Text('キャンセル'),
+                              onPressed: () => Navigator.pop(context),
+                            ),
+                            CupertinoDialogAction(
+                              child: Text('Get！'),
+                              onPressed: () => Navigator.pop(context),
+                            ),
+                          ],
+                        );
+                      },
+                    ),
                     color: Colors.greenAccent,
                     child: Text(
                       'クリアする',

--- a/lib/views/widgets/clear_comment_form.dart
+++ b/lib/views/widgets/clear_comment_form.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+class ClearCommentForm extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.all(10),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('コメント'),
+          TextField(
+            keyboardType: TextInputType.multiline,
+            decoration: InputDecoration(
+              hintText: 'クリアのコツや感想を教えてください',
+              border: OutlineInputBorder(),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/clear_quest_button.dart
+++ b/lib/views/widgets/clear_quest_button.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class ClearQuestButton extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      alignment: Alignment.center,
+      child: FlatButton(
+        color: Colors.green,
+        child: Text(
+          'クエストクリア',
+          style: TextStyle(
+            color: Colors.white,
+          ),
+        ),
+        onPressed: () => print('クエスト完了の処理'), // TODO: クエスト完了の処理
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/clear_quest_button.dart
+++ b/lib/views/widgets/clear_quest_button.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:g_sui_hunter/models/add_result_model.dart';
+import 'package:provider/provider.dart';
 
 class ClearQuestButton extends StatelessWidget {
   @override
@@ -13,7 +15,10 @@ class ClearQuestButton extends StatelessWidget {
             color: Colors.white,
           ),
         ),
-        onPressed: () => print('クエスト完了の処理'), // TODO: クエスト完了の処理
+        onPressed: () async {
+          await context.read<AddResultModel>().clearQuest();
+          await Navigator.pushNamedAndRemoveUntil(context, '/', (_) => false);
+        },
       ),
     );
   }

--- a/lib/views/widgets/clear_quest_image.dart
+++ b/lib/views/widgets/clear_quest_image.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+
+class ClearQuestImage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: EdgeInsets.all(8),
+      padding: EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: Colors.orange,
+        borderRadius: BorderRadius.circular(10),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black26,
+            spreadRadius: 1.0,
+            blurRadius: 10.0,
+            offset: Offset(10, 10),
+          ),
+        ],
+      ),
+      alignment: Alignment.center,
+      child: FittedBox(
+        fit: BoxFit.contain,
+        child: CachedNetworkImage(
+          placeholder: (context, url) => CircularProgressIndicator(),
+          imageUrl: '',
+          errorWidget: (context, url, error) => Icon(Icons.error),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/clear_quest_image.dart
+++ b/lib/views/widgets/clear_quest_image.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:g_sui_hunter/models/add_result_model.dart';
+import 'package:provider/provider.dart';
 
 class ClearQuestImage extends StatelessWidget {
   @override
@@ -22,10 +24,15 @@ class ClearQuestImage extends StatelessWidget {
       alignment: Alignment.center,
       child: FittedBox(
         fit: BoxFit.contain,
-        child: CachedNetworkImage(
-          placeholder: (context, url) => CircularProgressIndicator(),
-          imageUrl: '',
-          errorWidget: (context, url, error) => Icon(Icons.error),
+        child: Selector<AddResultModel, String>(
+          selector: (context, model) => model.currentQuest.imageUrl,
+          builder: (context, imageUrl, child) {
+            return CachedNetworkImage(
+              placeholder: (context, url) => CircularProgressIndicator(),
+              imageUrl: imageUrl,
+              errorWidget: (context, url, error) => Icon(Icons.error),
+            );
+          },
         ),
       ),
     );

--- a/lib/views/widgets/clear_quest_info.dart
+++ b/lib/views/widgets/clear_quest_info.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:auto_size_text/auto_size_text.dart';
+
+class ClearQuestInfo extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        return Column(
+          mainAxisAlignment: MainAxisAlignment.spaceAround,
+          children: [
+            Text(
+              'Rank0',
+              style: TextStyle(
+                fontSize: constraints.maxHeight * 0.1,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            AutoSizeText(
+              'デミグラスハンバーグ',
+              style: TextStyle(
+                fontSize: constraints.maxHeight * 0.2,
+                fontWeight: FontWeight.bold,
+              ),
+              maxLines: 2,
+              textAlign: TextAlign.center,
+            ),
+            Text(
+              'をクリア！',
+              style: TextStyle(
+                fontSize: constraints.maxHeight * 0.1,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/views/widgets/clear_quest_info.dart
+++ b/lib/views/widgets/clear_quest_info.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:auto_size_text/auto_size_text.dart';
+import 'package:g_sui_hunter/models/add_result_model.dart';
+import 'package:provider/provider.dart';
 
 class ClearQuestInfo extends StatelessWidget {
   @override
@@ -10,14 +12,14 @@ class ClearQuestInfo extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.spaceAround,
           children: [
             Text(
-              'Rank0',
+              'Rank${context.select<AddResultModel, int>((model) => model.currentQuest.rank)}',
               style: TextStyle(
                 fontSize: constraints.maxHeight * 0.1,
                 fontWeight: FontWeight.bold,
               ),
             ),
             AutoSizeText(
-              'デミグラスハンバーグ',
+              context.select<AddResultModel, String>((model) => model.currentQuest.title),
               style: TextStyle(
                 fontSize: constraints.maxHeight * 0.2,
                 fontWeight: FontWeight.bold,

--- a/lib/views/widgets/clear_time_form.dart
+++ b/lib/views/widgets/clear_time_form.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+class ClearTimeForm extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.all(10),
+      child:  Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Text(
+            'クリアタイム',
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          Flexible(
+            child: Padding(
+              padding: EdgeInsets.fromLTRB(20, 0, 20, 0),
+              child: TextField(
+                keyboardType: TextInputType.number,
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ),
+          Text(
+            '分',
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -8,6 +8,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.5.0-nullsafety.1"
+  auto_size_text:
+    dependency: "direct main"
+    description:
+      name: auto_size_text
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
   boolean_selector:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   google_sign_in: ^4.5.1
   decoratable_text: ^0.2.2
   cached_network_image: ^2.4.1
+  auto_size_text: ^2.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### やったこと
- クエスト結果画面を追加
- currentQuestのランク、タイトル、画像を表示
- クエストクリアボタンでcurrentQuestをnullに

### 画面
<img src='https://user-images.githubusercontent.com/39556764/101651694-b01f5380-3a80-11eb-83d9-f7e2739b445b.png' height='400'>

### 補足
- **[auto_text_size](https://pub.dev/packages/auto_size_text)というパッケージを追加したので @wanwan0622 はPodfileの更新を確認&コミットしてほしい**
- **レイアウトは端末に依存しないように意識したけど、自分の端末と写真で違ってるか確認してみてほしい**