### PR TITLE
クエストクリアでHunterのskills, quests, exp, rankを更新

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,0 +1,7 @@
+const Map<int, int> rankUpExpRule = {
+  1 : 30,
+  2 : 100,
+  3 : 300,
+  4 : 500,
+  5 : 500,
+};

--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -15,7 +15,7 @@ class AddResultModel extends ChangeNotifier {
     final currentQuestRef = hunterData.data()['currentQuest'];
     final currentQuestData = await currentQuestRef.get();
 
-    final hunterRank = await _calcRank(hunterData, currentQuestData);
+    final hunterRank = _calcRank(hunterData, currentQuestData);
 
     hunterRef.update({
       'currentQuest': null,
@@ -36,15 +36,15 @@ class AddResultModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future _calcRank(DocumentSnapshot hunterData, DocumentSnapshot currentQuestData) async {
-    final int preRank = await hunterData.data()['rank'];
+  int _calcRank(DocumentSnapshot hunterData, DocumentSnapshot currentQuestData) {
+    final int preRank = hunterData.data()['rank'];
 
     if (preRank == 5) {
       return preRank;
     }
 
     final int rankUpExp = rankUpExpRule[preRank];
-    final int preExp = await hunterData.data()['exp'];
+    final int preExp = hunterData.data()['exp'];
 
     if (rankUpExp <= preExp + preRank*10) {
       return preRank + 1;

--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -22,6 +22,7 @@ class AddResultModel extends ChangeNotifier {
       'exp': hunterRankAndExp['exp'],
       'currentQuest': null,
       'quests': FieldValue.arrayUnion([currentQuestRef]),
+      'skills': _calcSkills(hunterData, currentQuestData),
     });
     hunter.currentQuest = null;
     hunter.rank = hunterRankAndExp['rank'];
@@ -67,4 +68,25 @@ class AddResultModel extends ChangeNotifier {
     }
   }
 
+  Map<String, int> _calcSkills(DocumentSnapshot hunterData, DocumentSnapshot currentQuestData) {
+    Map<String, int> skills = {};
+    final List<dynamic> questTags = currentQuestData.data()['tags'];
+
+    final preSkills = hunterData.data()['skills'];
+    if (preSkills == null) {
+      questTags.forEach((tag) {
+        skills[tag] = 1;
+      });
+    } else {
+      skills = Map<String, int>.from(preSkills);
+      questTags.forEach((tag) {
+        if (skills[tag] == null) {
+          skills[tag] = 1;
+        } else {
+          skills[tag] += 1;
+        }
+      });
+    }
+    return skills;
+  }
 }

--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -16,17 +16,19 @@ class AddResultModel extends ChangeNotifier {
     final currentQuestData = await currentQuestRef.get();
 
     final hunterRankAndExp = _calcRankAndExp(hunterData, currentQuestData);
+    final hunterSkills = _calcSkills(hunterData, currentQuestData);
 
     hunterRef.update({
       'rank' : hunterRankAndExp['rank'],
       'exp': hunterRankAndExp['exp'],
       'currentQuest': null,
       'quests': FieldValue.arrayUnion([currentQuestRef]),
-      'skills': _calcSkills(hunterData, currentQuestData),
+      'skills': hunterSkills,
     });
     hunter.currentQuest = null;
     hunter.rank = hunterRankAndExp['rank'];
     hunter.exp = hunterRankAndExp['exp'];
+    hunter.skills = hunterSkills;
     notifyListeners();
   }
 

--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -24,6 +24,8 @@ class AddResultModel extends ChangeNotifier {
       'quests': FieldValue.arrayUnion([currentQuestRef]),
     });
     hunter.currentQuest = null;
+    hunter.rank = hunterRankAndExp['rank'];
+    hunter.exp = hunterRankAndExp['exp'];
     notifyListeners();
   }
 

--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -9,8 +9,13 @@ class AddResultModel extends ChangeNotifier {
 
   Future clearQuest() async {
     final hunterRef = FirebaseFirestore.instance.collection('hunters').doc(hunter.id);
+    final hunterData = await hunterRef.get();
+
+    final currentQuestRef = hunterData.data()['currentQuest'];
+
     hunterRef.update({
       'currentQuest': null,
+      'quests': FieldValue.arrayUnion([currentQuestRef]),
     });
     hunter.currentQuest = null;
     notifyListeners();

--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -12,10 +12,12 @@ class AddResultModel extends ChangeNotifier {
     final hunterData = await hunterRef.get();
 
     final currentQuestRef = hunterData.data()['currentQuest'];
+    final currentQuestData = await currentQuestRef.get();
 
     hunterRef.update({
       'currentQuest': null,
       'quests': FieldValue.arrayUnion([currentQuestRef]),
+      'exp': FieldValue.increment(currentQuestData.data()['rank']*10)
     });
     hunter.currentQuest = null;
     notifyListeners();

--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:g_sui_hunter/models/hunter.dart';
 import 'package:g_sui_hunter/models/quest.dart';
+import 'package:g_sui_hunter/constants.dart';
 
 class AddResultModel extends ChangeNotifier {
   Hunter hunter;
@@ -14,10 +15,13 @@ class AddResultModel extends ChangeNotifier {
     final currentQuestRef = hunterData.data()['currentQuest'];
     final currentQuestData = await currentQuestRef.get();
 
+    final hunterRank = await _calcRank(hunterData, currentQuestData);
+
     hunterRef.update({
       'currentQuest': null,
       'quests': FieldValue.arrayUnion([currentQuestRef]),
-      'exp': FieldValue.increment(currentQuestData.data()['rank']*10)
+      'rank' : hunterRank,
+      'exp': FieldValue.increment(currentQuestData.data()['rank']*10),
     });
     hunter.currentQuest = null;
     notifyListeners();
@@ -30,6 +34,23 @@ class AddResultModel extends ChangeNotifier {
     this.currentQuest = Quest(questSnapshot);
 
     notifyListeners();
+  }
+
+  Future _calcRank(DocumentSnapshot hunterData, DocumentSnapshot currentQuestData) async {
+    final int preRank = await hunterData.data()['rank'];
+
+    if (preRank == 5) {
+      return preRank;
+    }
+
+    final int rankUpExp = rankUpExpRule[preRank];
+    final int preExp = await hunterData.data()['exp'];
+
+    if (rankUpExp <= preExp + preRank*10) {
+      return preRank + 1;
+    } else {
+      return preRank;
+    }
   }
 
 }

--- a/lib/models/hunter.dart
+++ b/lib/models/hunter.dart
@@ -16,5 +16,5 @@ class Hunter{
   int exp;
   DocumentReference currentQuest;
   List<dynamic> quests;
-  Map<String, int> skills;
+  Map<String, dynamic> skills;
 }


### PR DESCRIPTION
### やったこと：タイトルの通り
### 画面
**今回は特に画面の変更はありません。firestoreのデータが更新されていくか確認してほしい**

### 補足
- rank up は `lib/constans.dart` の `rankUpExpRule`にあるように、30でランク2、100で3、300で4、500で5にした
- expやrankはランクアップに合わせてリセットされるようにした
- rank5になるとexpは500、rankは5で固定されるようにした
