### PR TITLE
クエストクリアでQuestのtime, Tagのquestsを更新

### DIFF
--- a/lib/models/add_quest_model.dart
+++ b/lib/models/add_quest_model.dart
@@ -42,6 +42,7 @@ class AddQuestModel extends ChangeNotifier {
       'siteUrl': '',
       'imageUrl': '',
       'rank': int.parse(this.groupValue),
+      'orderNum': 0,
       'timeAve': 0,
       'tags': _tags.toList(),
     });

--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -21,6 +21,8 @@ class AddResultModel extends ChangeNotifier {
     final currentQuestRef = hunterData.data()['currentQuest'];
     final currentQuestData = await currentQuestRef.get();
 
+    _updateCurrentQuestData(currentQuestData);
+
     final hunterRankAndExp = _calcRankAndExp(hunterData, currentQuestData);
     final hunterSkills = _calcSkills(hunterData, currentQuestData);
 
@@ -96,5 +98,18 @@ class AddResultModel extends ChangeNotifier {
       });
     }
     return skills;
+  }
+
+  Future _updateCurrentQuestData(DocumentSnapshot currentQuestData) async {
+    final int preTimeAve = currentQuestData.data()['timeAve'];
+    final int preOrderNum = currentQuestData.data()['orderNum'];
+
+    final timeAve = (preTimeAve * preOrderNum + this.clearTime) / (preOrderNum + 1);
+
+    await FirebaseFirestore.instance.collection('quests').doc(currentQuestData.id)
+        .update({
+      'orderNum': FieldValue.increment(1),
+      'timeAve': timeAve.round(),
+    });
   }
 }

--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -22,6 +22,7 @@ class AddResultModel extends ChangeNotifier {
     final currentQuestData = await currentQuestRef.get();
 
     _updateCurrentQuestData(currentQuestData);
+    _updateTagData(currentQuestRef, currentQuestData);
 
     final hunterRankAndExp = _calcRankAndExp(hunterData, currentQuestData);
     final hunterSkills = _calcSkills(hunterData, currentQuestData);
@@ -114,5 +115,24 @@ class AddResultModel extends ChangeNotifier {
 
     this.clearTime = null;
     notifyListeners();
+  }
+
+  Future _updateTagData(DocumentReference currentQuestRef, DocumentSnapshot currentQuestData) async {
+    final currentQuestTagList = currentQuestData.data()['tags'];
+    Future.forEach(
+        currentQuestTagList, (tag) async {
+      FirebaseFirestore.instance.collection('tags')
+          .where('name', isEqualTo: tag)
+          .limit(1)
+          .get()
+          .then((snapshot) {
+        final tagId = snapshot.docs.first.id;
+        FirebaseFirestore.instance.collection('tags')
+            .doc(tagId)
+            .update({
+          'quests': FieldValue.arrayUnion([currentQuestRef]),
+        });
+      });
+    });
   }
 }

--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -7,6 +7,12 @@ import 'package:g_sui_hunter/constants.dart';
 class AddResultModel extends ChangeNotifier {
   Hunter hunter;
   Quest currentQuest;
+  int clearTime;
+
+  void changeClearTime(int time) {
+    this.clearTime = time;
+    notifyListeners();
+  }
 
   Future clearQuest() async {
     final hunterRef = FirebaseFirestore.instance.collection('hunters').doc(hunter.id);

--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -111,5 +111,8 @@ class AddResultModel extends ChangeNotifier {
       'orderNum': FieldValue.increment(1),
       'timeAve': timeAve.round(),
     });
+
+    this.clearTime = null;
+    notifyListeners();
   }
 }

--- a/lib/models/quest.dart
+++ b/lib/models/quest.dart
@@ -7,6 +7,7 @@ class Quest {
     this.siteUrl = doc.data()['siteUrl'];
     this.imageUrl = doc.data()['imageUrl'];
     this.rank = doc.data()['rank'];
+    this.orderNum = doc.data()['orderNum'];
     this.timeAve = doc.data()['timeAve'];
     this.tags = doc.data()['tags'];
   }
@@ -15,6 +16,7 @@ class Quest {
   String siteUrl;
   String imageUrl;
   int rank;
+  int orderNum;
   int timeAve;
   List<dynamic> tags;
 }

--- a/lib/views/widgets/clear_time_form.dart
+++ b/lib/views/widgets/clear_time_form.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:g_sui_hunter/models/add_result_model.dart';
+import 'package:provider/provider.dart';
 
 class ClearTimeForm extends StatelessWidget {
   @override
@@ -21,6 +23,9 @@ class ClearTimeForm extends StatelessWidget {
               child: TextField(
                 keyboardType: TextInputType.number,
                 textAlign: TextAlign.center,
+                onChanged: (time) {
+                  context.read<AddResultModel>().changeClearTime(int.parse(time));
+                },
               ),
             ),
           ),


### PR DESCRIPTION
### やったこと：タイトルの通り
### 画面
**今回は特に画面の変更はありません。firestoreのデータが更新されていくか確認してほしい**

### 補足
- Questに新たにorderNumを追加、平均の算出に使用
