### PR TITLE
クエストクリアで新しくResultsのデータを追加

### DIFF
--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -8,9 +8,15 @@ class AddResultModel extends ChangeNotifier {
   Hunter hunter;
   Quest currentQuest;
   int clearTime;
+  String clearComment;
 
   void changeClearTime(int time) {
     this.clearTime = time;
+    notifyListeners();
+  }
+
+  void changeClearComment(String comment) {
+    this.clearComment = comment;
     notifyListeners();
   }
 

--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -29,6 +29,7 @@ class AddResultModel extends ChangeNotifier {
 
     _updateCurrentQuestData(currentQuestData);
     _updateTagData(currentQuestRef, currentQuestData);
+    _addResult(hunterRef, currentQuestRef);
 
     final hunterRankAndExp = _calcRankAndExp(hunterData, currentQuestData);
     final hunterSkills = _calcSkills(hunterData, currentQuestData);
@@ -120,7 +121,6 @@ class AddResultModel extends ChangeNotifier {
     });
 
     this.clearTime = null;
-    notifyListeners();
   }
 
   Future _updateTagData(DocumentReference currentQuestRef, DocumentSnapshot currentQuestData) async {
@@ -140,5 +140,16 @@ class AddResultModel extends ChangeNotifier {
         });
       });
     });
+  }
+
+  Future _addResult(DocumentReference hunterRef, DocumentReference currentQuestRef) async {
+    await FirebaseFirestore.instance.collection('results').add({
+      'hunterRef': hunterRef,
+      'questRef': currentQuestRef,
+      'comment': this.clearComment,
+      'clearedAt': FieldValue.serverTimestamp(),
+    })
+        .then((value) => print("New Result Added"))
+        .catchError((error) => print("Failed to add result: $error"));
   }
 }

--- a/lib/models/hunter.dart
+++ b/lib/models/hunter.dart
@@ -4,6 +4,7 @@ class Hunter{
   Hunter(DocumentSnapshot doc){
     this.id = doc.id;
     this.name = doc.data()['name'];
+    this.photoUrl = doc.data()['photoUrl'];
     this.rank = doc.data()['rank'];
     this.exp = doc.data()['exp'];
     this.currentQuest = doc.data()['currentQuest'];
@@ -12,6 +13,7 @@ class Hunter{
   }
   String id;
   String name;
+  String photoUrl;
   int rank;
   int exp;
   DocumentReference currentQuest;

--- a/lib/models/hunter_model.dart
+++ b/lib/models/hunter_model.dart
@@ -15,6 +15,7 @@ class HunterModel extends ChangeNotifier {
     if (hunterSnapshot.exists) {
       this.hunter = Hunter(hunterSnapshot);
       print("Welcome back");
+      notifyListeners();
     } else {
       hunterRef.set({
         'name': currentUser.displayName,
@@ -26,10 +27,10 @@ class HunterModel extends ChangeNotifier {
           .then((value) async {
         this.hunter = Hunter(await hunterRef.get());
         print("New Hunter Added");
+        notifyListeners();
       })
           .catchError((error) => print("Failed to add hunter: $error"));
     }
-    notifyListeners();
   }
 
   Future orderQuest(Quest data) async {

--- a/lib/models/hunter_model.dart
+++ b/lib/models/hunter_model.dart
@@ -18,6 +18,7 @@ class HunterModel extends ChangeNotifier {
     } else {
       hunterRef.set({
         'name': currentUser.displayName,
+        'photoUrl': currentUser.photoURL,
         'rank': 1,
         'exp': 0,
         'currentQuest': null,

--- a/lib/models/user_auth_model.dart
+++ b/lib/models/user_auth_model.dart
@@ -28,11 +28,13 @@ class UserAuthModel extends ChangeNotifier {
         accessToken: googleAuth.accessToken,
         idToken: googleAuth.idToken,
       );
-      this.isSignInWaiting = false;
-      return await FirebaseAuth.instance.signInWithCredential(credential);
+      await FirebaseAuth.instance.signInWithCredential(credential);
     } catch (error) {
+      this.isSignInWaiting = false;
+      notifyListeners();
       print(error);
     }
+    this.isSignInWaiting = false;
   }
 
   Future signOut() async {

--- a/lib/views/home_page.dart
+++ b/lib/views/home_page.dart
@@ -34,7 +34,7 @@ class HomePage extends StatelessWidget {
         actions: [
           CircleAvatar(
             backgroundImage: NetworkImage(
-              context.select<UserAuthModel, String>((value) => value.user.photoURL),
+              context.select<HunterModel, String>((value) => value.hunter.photoUrl),
             ),
           ),
           IconButton(

--- a/lib/views/sign_in_page.dart
+++ b/lib/views/sign_in_page.dart
@@ -10,13 +10,20 @@ class SignInPage extends StatelessWidget {
         title: Text('いざ、自炊ハンターの世界へ！'),
       ),
       body: Center(
-        child: context.select<UserAuthModel, bool>((value) => value.isSignInWaiting)
-            ? CircularProgressIndicator()
-            : RaisedButton(
-          child: Text('Sign in with google'),
-          onPressed: () async {
-            context.read<UserAuthModel>().switchWaitingState();
-            await context.read<UserAuthModel>().signIn();
+        child: Selector<UserAuthModel, bool>(
+          selector: (context, model) => model.isSignInWaiting,
+          builder: (context, isSignInWaiting, child) {
+            if (isSignInWaiting) {
+              return CircularProgressIndicator();
+            } else {
+              return RaisedButton(
+                child: Text('Sign in with google'),
+                onPressed: () async {
+                  context.read<UserAuthModel>().switchWaitingState();
+                  await context.read<UserAuthModel>().signIn();
+                },
+              );
+            }
           },
         ),
       ),

--- a/lib/views/widgets/clear_comment_form.dart
+++ b/lib/views/widgets/clear_comment_form.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:g_sui_hunter/models/add_result_model.dart';
+import 'package:provider/provider.dart';
 
 class ClearCommentForm extends StatelessWidget {
   @override
@@ -16,6 +18,9 @@ class ClearCommentForm extends StatelessWidget {
               hintText: 'クリアのコツや感想を教えてください',
               border: OutlineInputBorder(),
             ),
+            onChanged: (comment) {
+              context.read<AddResultModel>().changeClearComment(comment);
+            },
           ),
         ],
       ),


### PR DESCRIPTION
### やったこと
- firestore上のresultsコレクションにデータを追加
- resultsはUserRef, QuestRef, comment, clearedAtを持っている
- results一覧のためにhunterにphotoUrlを追加
- ↑に伴い認証機能のバグを修正
### 画面
今回は特に画面の変更はありません。
**クエストクリアの際にタイムとコメントを入力すればresultsデータが作成されるのを確認してほしい！**
### 補足
- Googleユーザーを削除したので念の為アプリを**アンインストールしてからビルド**し直してください
 