### PR TITLE
タグで検索画面を追加

### DIFF
--- a/lib/models/search_quest_model.dart
+++ b/lib/models/search_quest_model.dart
@@ -24,14 +24,19 @@ class SearchQuestModel extends ChangeNotifier {
           .limit(1)
           .get();
       final List<dynamic> questRefs = tagData.docs[0].data()['quests'];
-      final questList = [];
-      await Future.forEach(
-        questRefs, (questRef) async {
-        final questSnapshot = await questRef.get();
-        questList.add(Quest(questSnapshot));
-      },);
-      this.questList = List<Quest>.from(questList);
-      notifyListeners();
+      if (questRefs == null) {
+        this.questList = null;
+        notifyListeners();
+      } else {
+        final questList = [];
+        await Future.forEach(
+          questRefs, (questRef) async {
+          final questSnapshot = await questRef.get();
+          questList.add(Quest(questSnapshot));
+        },);
+        this.questList = List<Quest>.from(questList);
+        notifyListeners();
+      }
     }
   }
 }

--- a/lib/models/search_quest_model.dart
+++ b/lib/models/search_quest_model.dart
@@ -1,0 +1,21 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:g_sui_hunter/models/quest.dart';
+
+class SearchQuestModel extends ChangeNotifier {
+  List<Quest> questList = [];
+
+  void searchQuest(String tag) async {
+    final QuerySnapshot tagData = await FirebaseFirestore.instance
+        .collection('tags')
+        .where('name', isEqualTo: tag)
+        .limit(1)
+        .get();
+    final List<dynamic> questRefs = tagData.docs[0].data()['quests'];
+    Future.forEach(
+      questRefs, (questRef) async {
+        this.questList.add(Quest(await questRef.get()));
+    },);
+    notifyListeners();
+  }
+}

--- a/lib/models/search_quest_model.dart
+++ b/lib/models/search_quest_model.dart
@@ -12,10 +12,13 @@ class SearchQuestModel extends ChangeNotifier {
         .limit(1)
         .get();
     final List<dynamic> questRefs = tagData.docs[0].data()['quests'];
-    Future.forEach(
+    final questList = [];
+    await Future.forEach(
       questRefs, (questRef) async {
-        this.questList.add(Quest(await questRef.get()));
+        final questSnapshot = await questRef.get();
+        questList.add(Quest(questSnapshot));
     },);
+    this.questList = List<Quest>.from(questList);
     notifyListeners();
   }
 }

--- a/lib/models/search_quest_model.dart
+++ b/lib/models/search_quest_model.dart
@@ -4,6 +4,12 @@ import 'package:g_sui_hunter/models/quest.dart';
 
 class SearchQuestModel extends ChangeNotifier {
   List<Quest> questList = [];
+  String targetTag;
+
+  void changeTargetTag(tag) {
+    this.targetTag = tag;
+    notifyListeners();
+  }
 
   void searchQuest(String tag) async {
     final QuerySnapshot tagData = await FirebaseFirestore.instance

--- a/lib/models/search_quest_model.dart
+++ b/lib/models/search_quest_model.dart
@@ -11,20 +11,27 @@ class SearchQuestModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  void searchQuest(String tag) async {
-    final QuerySnapshot tagData = await FirebaseFirestore.instance
-        .collection('tags')
-        .where('name', isEqualTo: tag)
-        .limit(1)
-        .get();
-    final List<dynamic> questRefs = tagData.docs[0].data()['quests'];
-    final questList = [];
-    await Future.forEach(
-      questRefs, (questRef) async {
+  void searchQuest() async {
+    if (this.targetTag == null) {
+      final QuerySnapshot questSnapshots = await FirebaseFirestore.instance.collection('quests').orderBy('rank').get();
+      final questList = questSnapshots.docs.map((doc) => Quest(doc)).toList();
+      this.questList = questList;
+      notifyListeners();
+    } else {
+      final QuerySnapshot tagData = await FirebaseFirestore.instance
+          .collection('tags')
+          .where('name', isEqualTo: this.targetTag)
+          .limit(1)
+          .get();
+      final List<dynamic> questRefs = tagData.docs[0].data()['quests'];
+      final questList = [];
+      await Future.forEach(
+        questRefs, (questRef) async {
         final questSnapshot = await questRef.get();
         questList.add(Quest(questSnapshot));
-    },);
-    this.questList = List<Quest>.from(questList);
-    notifyListeners();
+      },);
+      this.questList = List<Quest>.from(questList);
+      notifyListeners();
+    }
   }
 }

--- a/lib/views/search_quest_page.dart
+++ b/lib/views/search_quest_page.dart
@@ -1,9 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:g_sui_hunter/models/quest.dart';
 import 'package:g_sui_hunter/views/widgets/current_quest_status.dart';
-import 'package:provider/provider.dart';
-import 'package:g_sui_hunter/models/quest_model.dart';
-import 'package:g_sui_hunter/views/widgets/quest_card.dart';
+import 'package:g_sui_hunter/views/widgets/seached_quest_list.dart';
 
 class SearchQuestPage extends StatelessWidget {
   @override
@@ -16,25 +13,7 @@ class SearchQuestPage extends StatelessWidget {
         ),
         Expanded(
           flex: 9,
-          child: RefreshIndicator(
-            onRefresh: () async => context.read<QuestModel>().fetchQuest(),
-            child: Selector<QuestModel, List<Quest>>(
-              builder: (context, model, child) {
-                final questList = model.map((quest) =>
-                    QuestCard(
-                      data: quest,
-                    ),
-                ).toList();
-                return GridView.count(
-                  mainAxisSpacing: 20.0,
-                  crossAxisSpacing: 20.0,
-                  crossAxisCount: 2,
-                  children: questList,
-                );
-              },
-              selector: (context, model) => model.questList,
-            ),
-          ),
+          child: SearchedQuestList(),
         ),
       ],
     );

--- a/lib/views/search_quest_page.dart
+++ b/lib/views/search_quest_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:g_sui_hunter/models/search_quest_model.dart';
 import 'package:g_sui_hunter/views/widgets/current_quest_status.dart';
 import 'package:g_sui_hunter/views/widgets/seached_quest_list.dart';
+import 'package:g_sui_hunter/views/widgets/serach_quest_form.dart';
 import 'package:provider/provider.dart';
 
 class SearchQuestPage extends StatelessWidget {
@@ -16,7 +17,11 @@ class SearchQuestPage extends StatelessWidget {
             child: CurrentQuestStatus(),
           ),
           Expanded(
-            flex: 9,
+            flex: 2,
+            child: SearchQuestForm(),
+          ),
+          Expanded(
+            flex: 7,
             child: SearchedQuestList(),
           ),
         ],

--- a/lib/views/search_quest_page.dart
+++ b/lib/views/search_quest_page.dart
@@ -1,7 +1,6 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
-import 'package:g_sui_hunter/models/hunter_model.dart';
 import 'package:g_sui_hunter/models/quest.dart';
+import 'package:g_sui_hunter/views/widgets/current_quest_status.dart';
 import 'package:provider/provider.dart';
 import 'package:g_sui_hunter/models/quest_model.dart';
 import 'package:g_sui_hunter/views/widgets/quest_card.dart';
@@ -13,32 +12,7 @@ class SearchQuestPage extends StatelessWidget {
       children: [
         Expanded(
           flex: 1,
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              Align(
-                alignment: Alignment.topRight,
-                child: Container(
-                  child: ButtonTheme(
-                    minWidth: 40.0,
-                    height: 20.0,
-                    child:  RaisedButton(
-                      child: Selector<HunterModel, DocumentReference>(
-                        selector: (context, model) => model.hunter.currentQuest,
-                        builder: (context, currentQuest, child) {
-                          if (currentQuest == null) {
-                            return Text("クエスト未選択");
-                          } else {
-                            return Text("クエスト中");
-                          }
-                        },
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-            ],
-          ),
+          child: CurrentQuestStatus(),
         ),
         Expanded(
           flex: 9,

--- a/lib/views/search_quest_page.dart
+++ b/lib/views/search_quest_page.dart
@@ -9,7 +9,7 @@ class SearchQuestPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<SearchQuestModel>(
-      create: (context) => SearchQuestModel()..searchQuest('フライパン'),
+      create: (context) => SearchQuestModel()..searchQuest(),
       child: Column(
         children: [
           Expanded(

--- a/lib/views/search_quest_page.dart
+++ b/lib/views/search_quest_page.dart
@@ -1,21 +1,26 @@
 import 'package:flutter/material.dart';
+import 'package:g_sui_hunter/models/search_quest_model.dart';
 import 'package:g_sui_hunter/views/widgets/current_quest_status.dart';
 import 'package:g_sui_hunter/views/widgets/seached_quest_list.dart';
+import 'package:provider/provider.dart';
 
 class SearchQuestPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        Expanded(
-          flex: 1,
-          child: CurrentQuestStatus(),
-        ),
-        Expanded(
-          flex: 9,
-          child: SearchedQuestList(),
-        ),
-      ],
+    return ChangeNotifierProvider<SearchQuestModel>(
+      create: (context) => SearchQuestModel()..searchQuest('フライパン'),
+      child: Column(
+        children: [
+          Expanded(
+            flex: 1,
+            child: CurrentQuestStatus(),
+          ),
+          Expanded(
+            flex: 9,
+            child: SearchedQuestList(),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/views/search_quest_page.dart
+++ b/lib/views/search_quest_page.dart
@@ -1,10 +1,68 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
+import 'package:g_sui_hunter/models/hunter_model.dart';
+import 'package:g_sui_hunter/models/quest.dart';
+import 'package:provider/provider.dart';
+import 'package:g_sui_hunter/models/quest_model.dart';
+import 'package:g_sui_hunter/views/widgets/quest_card.dart';
 
 class SearchQuestPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Text('This is search quest page.'),
+    return Column(
+      children: [
+        Expanded(
+          flex: 1,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              Align(
+                alignment: Alignment.topRight,
+                child: Container(
+                  child: ButtonTheme(
+                    minWidth: 40.0,
+                    height: 20.0,
+                    child:  RaisedButton(
+                      child: Selector<HunterModel, DocumentReference>(
+                        selector: (context, model) => model.hunter.currentQuest,
+                        builder: (context, currentQuest, child) {
+                          if (currentQuest == null) {
+                            return Text("クエスト未選択");
+                          } else {
+                            return Text("クエスト中");
+                          }
+                        },
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        Expanded(
+          flex: 9,
+          child: RefreshIndicator(
+            onRefresh: () async => context.read<QuestModel>().fetchQuest(),
+            child: Selector<QuestModel, List<Quest>>(
+              builder: (context, model, child) {
+                final questList = model.map((quest) =>
+                    QuestCard(
+                      data: quest,
+                    ),
+                ).toList();
+                return GridView.count(
+                  mainAxisSpacing: 20.0,
+                  crossAxisSpacing: 20.0,
+                  crossAxisCount: 2,
+                  children: questList,
+                );
+              },
+              selector: (context, model) => model.questList,
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/views/widgets/current_quest_status.dart
+++ b/lib/views/widgets/current_quest_status.dart
@@ -1,0 +1,36 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:g_sui_hunter/models/hunter_model.dart';
+import 'package:provider/provider.dart';
+
+class CurrentQuestStatus extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.end,
+      children: [
+        Align(
+          alignment: Alignment.topRight,
+          child: Container(
+            child: ButtonTheme(
+              minWidth: 40.0,
+              height: 20.0,
+              child:  RaisedButton(
+                child: Selector<HunterModel, DocumentReference>(
+                  selector: (context, model) => model.hunter.currentQuest,
+                  builder: (context, currentQuest, child) {
+                    if (currentQuest == null) {
+                      return Text("クエスト未選択");
+                    } else {
+                      return Text("クエスト中");
+                    }
+                  },
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/views/widgets/seached_quest_list.dart
+++ b/lib/views/widgets/seached_quest_list.dart
@@ -13,17 +13,21 @@ class SearchedQuestList extends StatelessWidget {
       child: Selector<SearchQuestModel, List<Quest>>(
         selector: (context, model) => model.questList,
         builder: (context, model, child) {
-          final questList = model.map((quest) =>
-              QuestCard(
-                data: quest,
-              ),
-          ).toList();
-          return GridView.count(
-            mainAxisSpacing: 20.0,
-            crossAxisSpacing: 20.0,
-            crossAxisCount: 2,
-            children: questList,
-          );
+          if (model == null) {
+            return Text('見つかりませんでした');
+          } else {
+            final questList = model.map((quest) =>
+                QuestCard(
+                  data: quest,
+                ),
+            ).toList();
+            return GridView.count(
+              mainAxisSpacing: 20.0,
+              crossAxisSpacing: 20.0,
+              crossAxisCount: 2,
+              children: questList,
+            );
+          }
         },
       ),
     );

--- a/lib/views/widgets/seached_quest_list.dart
+++ b/lib/views/widgets/seached_quest_list.dart
@@ -1,0 +1,30 @@
+import 'package:g_sui_hunter/models/quest.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:g_sui_hunter/models/quest_model.dart';
+import 'package:g_sui_hunter/views/widgets/quest_card.dart';
+
+class SearchedQuestList extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return RefreshIndicator(
+      onRefresh: () async => context.read<QuestModel>().fetchQuest(),
+      child: Selector<QuestModel, List<Quest>>(
+        builder: (context, model, child) {
+          final questList = model.map((quest) =>
+              QuestCard(
+                data: quest,
+              ),
+          ).toList();
+          return GridView.count(
+            mainAxisSpacing: 20.0,
+            crossAxisSpacing: 20.0,
+            crossAxisCount: 2,
+            children: questList,
+          );
+        },
+        selector: (context, model) => model.questList,
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/seached_quest_list.dart
+++ b/lib/views/widgets/seached_quest_list.dart
@@ -1,5 +1,6 @@
 import 'package:g_sui_hunter/models/quest.dart';
 import 'package:flutter/material.dart';
+import 'package:g_sui_hunter/models/search_quest_model.dart';
 import 'package:provider/provider.dart';
 import 'package:g_sui_hunter/models/quest_model.dart';
 import 'package:g_sui_hunter/views/widgets/quest_card.dart';
@@ -9,7 +10,8 @@ class SearchedQuestList extends StatelessWidget {
   Widget build(BuildContext context) {
     return RefreshIndicator(
       onRefresh: () async => context.read<QuestModel>().fetchQuest(),
-      child: Selector<QuestModel, List<Quest>>(
+      child: Selector<SearchQuestModel, List<Quest>>(
+        selector: (context, model) => model.questList,
         builder: (context, model, child) {
           final questList = model.map((quest) =>
               QuestCard(
@@ -23,7 +25,6 @@ class SearchedQuestList extends StatelessWidget {
             children: questList,
           );
         },
-        selector: (context, model) => model.questList,
       ),
     );
   }

--- a/lib/views/widgets/serach_quest_form.dart
+++ b/lib/views/widgets/serach_quest_form.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class SearchQuestForm extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.red,
+    );
+  }
+}

--- a/lib/views/widgets/serach_quest_form.dart
+++ b/lib/views/widgets/serach_quest_form.dart
@@ -1,10 +1,23 @@
 import 'package:flutter/material.dart';
+import 'package:g_sui_hunter/models/search_quest_model.dart';
+import 'package:g_sui_hunter/models/tag.dart';
+import 'package:g_sui_hunter/models/tag_model.dart';
+import 'package:provider/provider.dart';
 
 class SearchQuestForm extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Container(
-      color: Colors.red,
+    final tagList = context.select<TagModel, List<Tag>>((model) => model.tagList);
+    return DropdownButton(
+      value: context.select<SearchQuestModel, String>((model) => model.targetTag),
+      icon: Icon(Icons.search),
+      items: tagList.map((tag){
+        return DropdownMenuItem(
+          value: tag.name,
+          child: Text(tag.name),
+        );
+      }).toList(),
+      onChanged: (tag) => context.read<SearchQuestModel>().changeTargetTag(tag),
     );
   }
 }

--- a/lib/views/widgets/serach_quest_form.dart
+++ b/lib/views/widgets/serach_quest_form.dart
@@ -17,7 +17,10 @@ class SearchQuestForm extends StatelessWidget {
           child: Text(tag.name),
         );
       }).toList(),
-      onChanged: (tag) => context.read<SearchQuestModel>().changeTargetTag(tag),
+      onChanged: (tag) {
+        context.read<SearchQuestModel>().changeTargetTag(tag);
+        context.read<SearchQuestModel>().searchQuest();
+      },
     );
   }
 }


### PR DESCRIPTION
### やったこと
- ドロップダウンボタンでタグを選択できるようにした
- 選択したタグでクエスト検索をかけてみつかったものを表示
- なければ「見つかりませんでした」と表示

### 画面

<img src='https://user-images.githubusercontent.com/39556764/101807300-4ffbe080-3b58-11eb-8a24-9dead0df8684.png' width='200'><img src='https://user-images.githubusercontent.com/39556764/101807332-58ecb200-3b58-11eb-9dc4-704cc08ee0aa.png' width='200'><img src='https://user-images.githubusercontent.com/39556764/101807377-62761a00-3b58-11eb-85b8-1cc3d6e3a18d.png' width='200'>
### 補足
- Tagにはquestsっていってどんなクエストで使われているかのデータが用意されているんやけど、現在ほとんど設定していないので検索結果が実際より少なく表示されます