### PR TITLE
add_result_pageに入力バリデーションを追加

### DIFF
--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -21,11 +21,8 @@ class AddResultModel extends ChangeNotifier {
   }
 
   Future clearQuest() async {
-    final hunterRef = FirebaseFirestore.instance.collection('hunters').doc(hunter.id);
-    final hunterData = await hunterRef.get();
-
-    final currentQuestRef = hunterData.data()['currentQuest'];
-    final currentQuestData = await currentQuestRef.get();
+    final hunterRef = FirebaseFirestore.instance.collection('hunters').doc(this.hunter.id);
+    final currentQuestRef = FirebaseFirestore.instance.collection('quests').doc(this.currentQuest.id);
 
     await _updateCurrentQuestData();
     await _updateTagData();

--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -25,9 +25,9 @@ class AddResultModel extends ChangeNotifier {
     final currentQuestRef = FirebaseFirestore.instance.collection('quests').doc(this.currentQuest.id);
 
     await _updateHunterData(hunterRef, currentQuestRef);
-    await _updateCurrentQuestData();
-    await _updateTagData();
-    await _addResultData();
+    await _updateCurrentQuestData(currentQuestRef);
+    await _updateTagData(currentQuestRef);
+    await _addResultData(hunterRef, currentQuestRef);
   }
 
   Future createState(Hunter hunter) async {
@@ -103,22 +103,20 @@ class AddResultModel extends ChangeNotifier {
     return skills;
   }
 
-  Future _updateCurrentQuestData() async {
+  Future _updateCurrentQuestData(DocumentReference currentQuestRef) async {
     final int preTimeAve = this.currentQuest.timeAve;
     final int preOrderNum = this.currentQuest.orderNum;
 
     final timeAve = (preTimeAve * preOrderNum + this.clearTime) / (preOrderNum + 1);
 
-    await FirebaseFirestore.instance.collection('quests').doc(this.currentQuest.id)
-        .update({
+    await currentQuestRef.update({
       'orderNum': FieldValue.increment(1),
       'timeAve': timeAve.round(),
     });
   }
 
-  Future _updateTagData() async {
+  Future _updateTagData(DocumentReference currentQuestRef) async {
     final currentQuestTagList = this.currentQuest.tags;
-    final currentQuestRef = FirebaseFirestore.instance.collection('quests').doc(this.currentQuest.id);
     Future.forEach(
         currentQuestTagList, (tag) async {
       FirebaseFirestore.instance.collection('tags')
@@ -136,10 +134,10 @@ class AddResultModel extends ChangeNotifier {
     });
   }
 
-  Future _addResultData() async {
+  Future _addResultData(DocumentReference hunterRef, DocumentReference currentQuestRef) async {
     await FirebaseFirestore.instance.collection('results').add({
-      'hunterRef': FirebaseFirestore.instance.collection('hunters').doc(this.hunter.id),
-      'questRef': FirebaseFirestore.instance.collection('quests').doc(this.currentQuest.id),
+      'hunterRef': hunterRef,
+      'questRef': currentQuestRef,
       'comment': this.clearComment,
       'clearedAt': FieldValue.serverTimestamp(),
     })

--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -31,7 +31,7 @@ class AddResultModel extends ChangeNotifier {
     await _updateTagData();
     await _addResult();
 
-    final hunterRankAndExp = _calcRankAndExp(hunterData, currentQuestData);
+    final hunterRankAndExp = _calcRankAndExp();
     final hunterSkills = _calcSkills(hunterData, currentQuestData);
 
     hunterRef.update({
@@ -52,9 +52,9 @@ class AddResultModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  Map<String, int> _calcRankAndExp(DocumentSnapshot hunterData, DocumentSnapshot currentQuestData) {
-    final int preRank = hunterData.data()['rank'];
-    final int questRank = currentQuestData.data()['rank'];
+  Map<String, int> _calcRankAndExp() {
+    final int preRank = this.hunter.rank;
+    final int questRank = this.currentQuest.rank;
 
     if (preRank == 5) {
       return {
@@ -64,7 +64,7 @@ class AddResultModel extends ChangeNotifier {
     }
 
     final int rankUpExp = rankUpExpRule[preRank];
-    final int preExp = hunterData.data()['exp'];
+    final int preExp = this.hunter.exp;
 
     final bool isRankUp = (rankUpExp <= preExp + questRank*10);
     if (isRankUp) {

--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -27,9 +27,9 @@ class AddResultModel extends ChangeNotifier {
     final currentQuestRef = hunterData.data()['currentQuest'];
     final currentQuestData = await currentQuestRef.get();
 
-    _updateCurrentQuestData(currentQuestData);
-    _updateTagData(currentQuestRef, currentQuestData);
-    _addResult(hunterRef, currentQuestRef);
+    await _updateCurrentQuestData(currentQuestData);
+    await _updateTagData(currentQuestRef, currentQuestData);
+    await _addResult(hunterRef, currentQuestRef);
 
     final hunterRankAndExp = _calcRankAndExp(hunterData, currentQuestData);
     final hunterSkills = _calcSkills(hunterData, currentQuestData);

--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -138,6 +138,7 @@ class AddResultModel extends ChangeNotifier {
     await FirebaseFirestore.instance.collection('results').add({
       'hunterRef': hunterRef,
       'questRef': currentQuestRef,
+      'time': this.clearTime,
       'comment': this.clearComment,
       'clearedAt': FieldValue.serverTimestamp(),
     })

--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -41,11 +41,6 @@ class AddResultModel extends ChangeNotifier {
       'quests': FieldValue.arrayUnion([currentQuestRef]),
       'skills': hunterSkills,
     });
-    hunter.currentQuest = null;
-    hunter.rank = hunterRankAndExp['rank'];
-    hunter.exp = hunterRankAndExp['exp'];
-    hunter.skills = hunterSkills;
-    notifyListeners();
   }
 
   Future createState(Hunter hunter) async {
@@ -119,8 +114,6 @@ class AddResultModel extends ChangeNotifier {
       'orderNum': FieldValue.increment(1),
       'timeAve': timeAve.round(),
     });
-
-    this.clearTime = null;
   }
 
   Future _updateTagData(DocumentReference currentQuestRef, DocumentSnapshot currentQuestData) async {

--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -27,7 +27,7 @@ class AddResultModel extends ChangeNotifier {
     await _updateHunterData(hunterRef, currentQuestRef);
     await _updateCurrentQuestData();
     await _updateTagData();
-    await _addResult();
+    await _addResultData();
   }
 
   Future createState(Hunter hunter) async {
@@ -136,7 +136,7 @@ class AddResultModel extends ChangeNotifier {
     });
   }
 
-  Future _addResult() async {
+  Future _addResultData() async {
     await FirebaseFirestore.instance.collection('results').add({
       'hunterRef': FirebaseFirestore.instance.collection('hunters').doc(this.hunter.id),
       'questRef': FirebaseFirestore.instance.collection('quests').doc(this.currentQuest.id),

--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -24,10 +24,22 @@ class AddResultModel extends ChangeNotifier {
     final hunterRef = FirebaseFirestore.instance.collection('hunters').doc(this.hunter.id);
     final currentQuestRef = FirebaseFirestore.instance.collection('quests').doc(this.currentQuest.id);
 
+    await _updateHunterData(hunterRef, currentQuestRef);
     await _updateCurrentQuestData();
     await _updateTagData();
     await _addResult();
+  }
 
+  Future createState(Hunter hunter) async {
+    this.hunter = hunter;
+
+    final questSnapshot = await hunter.currentQuest.get();
+    this.currentQuest = Quest(questSnapshot);
+
+    notifyListeners();
+  }
+
+  Future _updateHunterData(DocumentReference hunterRef, DocumentReference currentQuestRef) async {
     final hunterRankAndExp = _calcRankAndExp();
     final hunterSkills = _calcSkills();
 
@@ -38,15 +50,6 @@ class AddResultModel extends ChangeNotifier {
       'quests': FieldValue.arrayUnion([currentQuestRef]),
       'skills': hunterSkills,
     });
-  }
-
-  Future createState(Hunter hunter) async {
-    this.hunter = hunter;
-
-    final questSnapshot = await hunter.currentQuest.get();
-    this.currentQuest = Quest(questSnapshot);
-
-    notifyListeners();
   }
 
   Map<String, int> _calcRankAndExp() {

--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -27,7 +27,7 @@ class AddResultModel extends ChangeNotifier {
     final currentQuestRef = hunterData.data()['currentQuest'];
     final currentQuestData = await currentQuestRef.get();
 
-    await _updateCurrentQuestData(currentQuestData);
+    await _updateCurrentQuestData();
     await _updateTagData(currentQuestRef, currentQuestData);
     await _addResult(hunterRef, currentQuestRef);
 
@@ -103,13 +103,13 @@ class AddResultModel extends ChangeNotifier {
     return skills;
   }
 
-  Future _updateCurrentQuestData(DocumentSnapshot currentQuestData) async {
-    final int preTimeAve = currentQuestData.data()['timeAve'];
-    final int preOrderNum = currentQuestData.data()['orderNum'];
+  Future _updateCurrentQuestData() async {
+    final int preTimeAve = this.currentQuest.timeAve;
+    final int preOrderNum = this.currentQuest.orderNum;
 
     final timeAve = (preTimeAve * preOrderNum + this.clearTime) / (preOrderNum + 1);
 
-    await FirebaseFirestore.instance.collection('quests').doc(currentQuestData.id)
+    await FirebaseFirestore.instance.collection('quests').doc(this.currentQuest.id)
         .update({
       'orderNum': FieldValue.increment(1),
       'timeAve': timeAve.round(),

--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -8,7 +8,7 @@ class AddResultModel extends ChangeNotifier {
   Hunter hunter;
   Quest currentQuest;
   int clearTime;
-  String clearComment;
+  String clearComment = '';
 
   void changeClearTime(int time) {
     this.clearTime = time;

--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -28,7 +28,7 @@ class AddResultModel extends ChangeNotifier {
     final currentQuestData = await currentQuestRef.get();
 
     await _updateCurrentQuestData();
-    await _updateTagData(currentQuestRef, currentQuestData);
+    await _updateTagData();
     await _addResult(hunterRef, currentQuestRef);
 
     final hunterRankAndExp = _calcRankAndExp(hunterData, currentQuestData);
@@ -116,8 +116,9 @@ class AddResultModel extends ChangeNotifier {
     });
   }
 
-  Future _updateTagData(DocumentReference currentQuestRef, DocumentSnapshot currentQuestData) async {
-    final currentQuestTagList = currentQuestData.data()['tags'];
+  Future _updateTagData() async {
+    final currentQuestTagList = this.currentQuest.tags;
+    final currentQuestRef = FirebaseFirestore.instance.collection('quests').doc(this.currentQuest.id);
     Future.forEach(
         currentQuestTagList, (tag) async {
       FirebaseFirestore.instance.collection('tags')

--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -32,7 +32,7 @@ class AddResultModel extends ChangeNotifier {
     await _addResult();
 
     final hunterRankAndExp = _calcRankAndExp();
-    final hunterSkills = _calcSkills(hunterData, currentQuestData);
+    final hunterSkills = _calcSkills();
 
     hunterRef.update({
       'rank' : hunterRankAndExp['rank'],
@@ -81,11 +81,11 @@ class AddResultModel extends ChangeNotifier {
     }
   }
 
-  Map<String, int> _calcSkills(DocumentSnapshot hunterData, DocumentSnapshot currentQuestData) {
+  Map<String, int> _calcSkills() {
     Map<String, int> skills = {};
-    final List<dynamic> questTags = currentQuestData.data()['tags'];
+    final List<dynamic> questTags = this.currentQuest.tags;
 
-    final preSkills = hunterData.data()['skills'];
+    final preSkills = this.hunter.skills;
     if (preSkills == null) {
       questTags.forEach((tag) {
         skills[tag] = 1;

--- a/lib/models/add_result_model.dart
+++ b/lib/models/add_result_model.dart
@@ -29,7 +29,7 @@ class AddResultModel extends ChangeNotifier {
 
     await _updateCurrentQuestData();
     await _updateTagData();
-    await _addResult(hunterRef, currentQuestRef);
+    await _addResult();
 
     final hunterRankAndExp = _calcRankAndExp(hunterData, currentQuestData);
     final hunterSkills = _calcSkills(hunterData, currentQuestData);
@@ -136,10 +136,10 @@ class AddResultModel extends ChangeNotifier {
     });
   }
 
-  Future _addResult(DocumentReference hunterRef, DocumentReference currentQuestRef) async {
+  Future _addResult() async {
     await FirebaseFirestore.instance.collection('results').add({
-      'hunterRef': hunterRef,
-      'questRef': currentQuestRef,
+      'hunterRef': FirebaseFirestore.instance.collection('hunters').doc(this.hunter.id),
+      'questRef': FirebaseFirestore.instance.collection('quests').doc(this.currentQuest.id),
       'comment': this.clearComment,
       'clearedAt': FieldValue.serverTimestamp(),
     })

--- a/lib/models/quest_model.dart
+++ b/lib/models/quest_model.dart
@@ -5,7 +5,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 class QuestModel extends ChangeNotifier {
   List<Quest> questList = [];
 
-  void fetchQuest() async {
+  Future fetchQuest() async {
     final QuerySnapshot questSnapshots = await FirebaseFirestore.instance.collection('quests').orderBy('rank').get();
     final questList = questSnapshots.docs.map((doc) => Quest(doc)).toList();
     this.questList = questList;

--- a/lib/models/tag_model.dart
+++ b/lib/models/tag_model.dart
@@ -5,7 +5,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 class TagModel extends ChangeNotifier {
   List<Tag> tagList = [];
 
-  void fetchTag() async {
+  Future fetchTag() async {
     final QuerySnapshot tagSnapshots = await FirebaseFirestore.instance.collection('tags').get();
     final tagList = tagSnapshots.docs.map((doc) => Tag(doc)).toList();
     this.tagList = tagList;

--- a/lib/views/widgets/clear_quest_button.dart
+++ b/lib/views/widgets/clear_quest_button.dart
@@ -1,23 +1,59 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:g_sui_hunter/models/add_result_model.dart';
 import 'package:provider/provider.dart';
+import 'package:tuple/tuple.dart';
 
 class ClearQuestButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
       alignment: Alignment.center,
-      child: FlatButton(
-        color: Colors.green,
-        child: Text(
-          'クエストクリア',
-          style: TextStyle(
-            color: Colors.white,
-          ),
-        ),
-        onPressed: () async {
-          await context.read<AddResultModel>().clearQuest();
-          await Navigator.pushNamedAndRemoveUntil(context, '/', (_) => false);
+      child: Selector<AddResultModel, Tuple2<String, int>>(
+        selector: (context, model) => Tuple2(model.clearComment, model.clearTime),
+        builder: (context, data, child ) {
+          if (data.item1.isEmpty || data.item2 == null) {
+            return FlatButton(
+              color: Colors.grey,
+              child: Text(
+                'クエストクリア',
+                style: TextStyle(
+                  color: Colors.white,
+                ),
+              ),
+              onPressed: () async {
+                showDialog(
+                  context: context,
+                  builder: (context) {
+                    return CupertinoAlertDialog(
+                      title: Text('まだだよ…'),
+                      content: Text('クリアタイムとコメントを入力してね'),
+                      actions: [
+                        CupertinoDialogAction(
+                          child: Text('OK'),
+                          onPressed: () => Navigator.pop(context),
+                        ),
+                      ],
+                    );
+                  },
+                );
+              },
+            );
+          } else {
+            return FlatButton(
+              color: Colors.green,
+              child: Text(
+                'クエストクリア',
+                style: TextStyle(
+                  color: Colors.white,
+                ),
+              ),
+              onPressed: () async {
+                await context.read<AddResultModel>().clearQuest();
+                await Navigator.pushNamedAndRemoveUntil(context, '/', (_) => false);
+              },
+            );
+          }
         },
       ),
     );

--- a/lib/views/widgets/clear_quest_button.dart
+++ b/lib/views/widgets/clear_quest_button.dart
@@ -53,9 +53,9 @@ class ClearQuestButton extends StatelessWidget {
               ),
               onPressed: () async {
                 await context.read<AddResultModel>().clearQuest();
-                await context.read<HunterModel>().fetchHunter();
-                await context.read<QuestModel>().fetchQuest();
-                await context.read<TagModel>().fetchTag();
+                context.read<HunterModel>().fetchHunter();
+                context.read<QuestModel>().fetchQuest();
+                context.read<TagModel>().fetchTag();
                 await Navigator.pushNamedAndRemoveUntil(context, '/', (_) => false);
               },
             );

--- a/lib/views/widgets/clear_quest_button.dart
+++ b/lib/views/widgets/clear_quest_button.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:g_sui_hunter/models/add_result_model.dart';
+import 'package:g_sui_hunter/models/hunter_model.dart';
+import 'package:g_sui_hunter/models/quest_model.dart';
+import 'package:g_sui_hunter/models/tag_model.dart';
 import 'package:provider/provider.dart';
 import 'package:tuple/tuple.dart';
 
@@ -50,6 +53,9 @@ class ClearQuestButton extends StatelessWidget {
               ),
               onPressed: () async {
                 await context.read<AddResultModel>().clearQuest();
+                await context.read<HunterModel>().fetchHunter();
+                await context.read<QuestModel>().fetchQuest();
+                await context.read<TagModel>().fetchTag();
                 await Navigator.pushNamedAndRemoveUntil(context, '/', (_) => false);
               },
             );

--- a/lib/views/widgets/clear_time_form.dart
+++ b/lib/views/widgets/clear_time_form.dart
@@ -24,7 +24,7 @@ class ClearTimeForm extends StatelessWidget {
                 keyboardType: TextInputType.number,
                 textAlign: TextAlign.center,
                 onChanged: (time) {
-                  context.read<AddResultModel>().changeClearTime(int.parse(time));
+                  context.read<AddResultModel>().changeClearTime(int.tryParse(time));
                 },
               ),
             ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -434,6 +434,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.19-nullsafety.2"
+  tuple:
+    dependency: "direct main"
+    description:
+      name: tuple
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.3"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   decoratable_text: ^0.2.2
   cached_network_image: ^2.4.1
   auto_size_text: ^2.1.0
+  tuple: ^1.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### やったこと
- クリアタイムとクリアコメントを入力しないとクリアできない
- ボタンを押すとエラーダイアログを表示
- clear quest の処理で無駄なものを省きました
- clear quest 完了後にfirestoreのデータをfetchするようにした

### 画面
<img src='https://user-images.githubusercontent.com/39556764/101865113-bc0e3100-3bb8-11eb-8bbe-cf97774e38dd.png' width='200'><img src='https://user-images.githubusercontent.com/39556764/101865121-c3353f00-3bb8-11eb-887c-8b1f7dec8e9c.png' width='200'><img src='https://user-images.githubusercontent.com/39556764/101865134-cc261080-3bb8-11eb-8925-d4fbfaf6cce4.png' width='200'>

### 補足
- [tuple](https://pub.dev/packages/tuple) パッケージを入れたので追加でpub getが必要